### PR TITLE
Use EPEL convenience URLs

### DIFF
--- a/run-job
+++ b/run-job
@@ -45,21 +45,19 @@ osg_series=`grep series $INPUT_DIR/osg-test.conf | sed -e 's/series *= *//'`
 
 # Set variables based on OS major version
 os_major_version=`sed -e 's/^[^0-9]*//' -e 's/\..*$//' /etc/redhat-release`
+epel_url="https://dl.fedoraproject.org/pub/epel/epel-release-latest-$os_major_version.noarch.rpm"
 case $os_major_version in
     5 )
-        epel_url='http://dl.fedoraproject.org/pub/epel/5/i386/epel-release-5-4.noarch.rpm'
         osg_url="http://repo.grid.iu.edu/osg/$osg_series/osg-$osg_series-el5-release-latest.rpm"
         priorities_rpm='yum-priorities'
         python_lib_dir='/usr/lib/python2.4'
         ;;
     6 )
-        epel_url='http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm'
         osg_url="http://repo.grid.iu.edu/osg/$osg_series/osg-$osg_series-el6-release-latest.rpm"
         priorities_rpm='yum-plugin-priorities'
         python_lib_dir='/usr/lib/python2.6'
         ;;
     7 )
-        epel_url='http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm'
         osg_url="http://repo.grid.iu.edu/osg/$osg_series/osg-$osg_series-el7-release-latest.rpm"
         priorities_rpm='yum-plugin-priorities'
         python_lib_dir='/usr/lib/python2.7'


### PR DESCRIPTION
From @efajardo's e-mail:

> I saw today some of my test failing by not finding the right epel:
> 
> http://vdt.cs.wisc.edu/tests/20160419-1726/012/run-job.log
> 
> package epel-release is not installed
> 2016-04-19 17:39:01: rpm --upgrade http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
> curl: (22) The requested URL returned error: 404 Not Found
> error: skipping http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm - transfer failed
> ==> FAILED with exit status 1
> 
> 
> 
> I looked in the code of run_job for the automated tests and they were using the old urls, can you change them to the new ones:
> 
> epel_url='https://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm'
> epel_url='https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm'
> epel_url='https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm'
> 
> I change them manually now on every test that I ran but I would rather get that fix at the source.