### PR TITLE
Add automated test runs with and without GRAM (SOFTWARE-2291)

### DIFF
--- a/parameters.d/osg32.yaml
+++ b/parameters.d/osg32.yaml
@@ -13,11 +13,6 @@ sources:
 
 packages:
   - All: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal]
-  # Explicitly add GRAM packages since they were dropped from osg-ce (SOFTWARE-2278, SOFTWARE-2291)
-  - GRAM: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal,
-           globus-gatekeeper, globus-gram-client-tools, globus-gram-job-manager, globus-gram-job-manager-fork,
-           globus-gram-job-manager-fork-setup-poll, gratia-probe-gram, globus-gram-job-manager-scripts,
-           globus-gram-job-manager-condor, globus-gram-job-manager-pbs-setup-seg]
   - HTCondor: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, condor.x86_64, osg-ce-condor, rsv]
   - GridFTP: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-gridftp, edg-mkgridmap, rsv]
   - BeStMan: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-se-bestman, rsv]

--- a/parameters.d/osg32.yaml
+++ b/parameters.d/osg32.yaml
@@ -13,6 +13,11 @@ sources:
 
 packages:
   - All: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal]
+  # Explicitly add GRAM packages since they were dropped from osg-ce (SOFTWARE-2278, SOFTWARE-2291)
+  - GRAM: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal,
+           globus-gatekeeper, globus-gram-client-tools, globus-gram-job-manager, globus-gram-job-manager-fork,
+           globus-gram-job-manager-fork-setup-poll, gratia-probe-gram, globus-gram-job-manager-scripts,
+           globus-gram-job-manager-condor, globus-gram-job-manager-pbs-setup-seg]
   - HTCondor: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, condor.x86_64, osg-ce-condor, rsv]
   - GridFTP: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-gridftp, edg-mkgridmap, rsv]
   - BeStMan: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-se-bestman, rsv]

--- a/parameters.d/osg33-el6.yaml
+++ b/parameters.d/osg33-el6.yaml
@@ -14,6 +14,11 @@ sources:
 
 packages:
   - All: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal]
+  # Explicitly add GRAM packages since they were dropped from osg-ce (SOFTWARE-2278, SOFTWARE-2291)
+  - GRAM: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal,
+           globus-gatekeeper, globus-gram-client-tools, globus-gram-job-manager, globus-gram-job-manager-fork,
+           globus-gram-job-manager-fork-setup-poll, gratia-probe-gram, globus-gram-job-manager-scripts,
+           globus-gram-job-manager-condor, globus-gram-job-manager-pbs-setup-seg]
   - HTCondor: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, condor.x86_64, osg-ce-condor, rsv]
   - GridFTP: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-gridftp, edg-mkgridmap, rsv]
   - BeStMan: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-se-bestman, rsv]

--- a/parameters.d/osg33-el6.yaml
+++ b/parameters.d/osg33-el6.yaml
@@ -15,10 +15,10 @@ sources:
 packages:
   - All: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal]
   # Explicitly add GRAM packages since they were dropped from osg-ce (SOFTWARE-2278, SOFTWARE-2291)
-  - GRAM: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal,
-           globus-gatekeeper, globus-gram-client-tools, globus-gram-job-manager, globus-gram-job-manager-fork,
-           globus-gram-job-manager-fork-setup-poll, gratia-probe-gram, globus-gram-job-manager-scripts,
-           globus-gram-job-manager-condor, globus-gram-job-manager-pbs-setup-seg]
+  - All + GRAM: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal,
+                 globus-gatekeeper, globus-gram-client-tools, globus-gram-job-manager, globus-gram-job-manager-fork,
+                 globus-gram-job-manager-fork-setup-poll, gratia-probe-gram, globus-gram-job-manager-scripts,
+                 globus-gram-job-manager-condor, globus-gram-job-manager-pbs-setup-seg]
   - HTCondor: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, condor.x86_64, osg-ce-condor, rsv]
   - GridFTP: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-gridftp, edg-mkgridmap, rsv]
   - BeStMan: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-se-bestman, rsv]

--- a/parameters.d/osg33-el7.yaml
+++ b/parameters.d/osg33-el7.yaml
@@ -12,5 +12,10 @@ sources:
 
 packages:
   - All: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal]
+  # Explicitly add GRAM packages since they were dropped from osg-ce (SOFTWARE-2278, SOFTWARE-2291)
+  - GRAM: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal,
+           globus-gatekeeper, globus-gram-client-tools, globus-gram-job-manager, globus-gram-job-manager-fork,
+           globus-gram-job-manager-fork-setup-poll, gratia-probe-gram, globus-gram-job-manager-scripts,
+           globus-gram-job-manager-condor, globus-gram-job-manager-pbs-setup-seg]
   - HTCondor: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, condor.x86_64, osg-ce-condor, rsv]
   - GridFTP: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-gridftp, edg-mkgridmap, rsv]

--- a/parameters.d/osg33-el7.yaml
+++ b/parameters.d/osg33-el7.yaml
@@ -13,9 +13,9 @@ sources:
 packages:
   - All: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal]
   # Explicitly add GRAM packages since they were dropped from osg-ce (SOFTWARE-2278, SOFTWARE-2291)
-  - GRAM: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal,
-           globus-gatekeeper, globus-gram-client-tools, globus-gram-job-manager, globus-gram-job-manager-fork,
-           globus-gram-job-manager-fork-setup-poll, gratia-probe-gram, globus-gram-job-manager-scripts,
-           globus-gram-job-manager-condor, globus-gram-job-manager-pbs-setup-seg]
+  - All + GRAM: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal,
+                 globus-gatekeeper, globus-gram-client-tools, globus-gram-job-manager, globus-gram-job-manager-fork,
+                 globus-gram-job-manager-fork-setup-poll, gratia-probe-gram, globus-gram-job-manager-scripts,
+                 globus-gram-job-manager-condor, globus-gram-job-manager-pbs-setup-seg]
   - HTCondor: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, condor.x86_64, osg-ce-condor, rsv]
   - GridFTP: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-gridftp, edg-mkgridmap, rsv]


### PR DESCRIPTION
Tests look good here (other than fetch-crl failures): http://vdt.cs.wisc.edu/tests/20160503-1238/results.html. I did a quick spot check to verify that the GRAM packages were installed.

List of package acquired from [SOFTWARE-2290](https://jira.opensciencegrid.org/browse/SOFTWARE-2290)