### PR TITLE
Allow osg-test to be installed out of any repo and/or branch

### DIFF
--- a/create-io-images
+++ b/create-io-images
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-
+import vmu
 
 def run_command(command, shell=False):
     # Preprocess command
@@ -124,7 +124,7 @@ if __name__ == '__main__':
 
     # Process command-line arguments
     if len(sys.argv) != 1:
-        die('usage: %s' % (script_name))
+        vmu.die('usage: %s' % (script_name))
 
     # Write files
     contents_to_filename = {}

--- a/create-io-images
+++ b/create-io-images
@@ -23,8 +23,16 @@ def run_command(command, shell=False):
     return (p.returncode, stdout, stderr)
 
 
-def make_source_tarball_from_github(package, revision='master'):
-    source_dir_name = package + '-' + revision
+def make_source_tarball_from_github(package, repo='opensciencegrid', branch='master'):
+    """
+    Generate a tarball containing the bare github clone of 'package' using the
+    'branch' from 'repo'.
+
+    package: name of the package on github
+    repo: source github repository
+    branch: source branch or tag
+    """
+    source_dir_name = package + '-git'
     source_tarball_name = source_dir_name + '.tar.gz'
     # Return immediately if the source tarball seems to exist already
     if os.path.exists(source_tarball_name):
@@ -33,7 +41,7 @@ def make_source_tarball_from_github(package, revision='master'):
     # Clone the repo into a temporary directory
     temp_directory = tempfile.mkdtemp()
     clone_directory = os.path.join(temp_directory, source_dir_name + '.git')
-    command = ('git', 'clone', '--bare', 'https://github.com/opensciencegrid/' + package, clone_directory)
+    command = ('git', 'clone', '--bare', '--branch', branch, 'https://github.com/%s/%s' % (repo, package), clone_directory)
     (exit_status, stdout, stderr) = run_command(command)
     if exit_status != 0:
         print 'git clone failed with exit status %d' % exit_status
@@ -41,11 +49,11 @@ def make_source_tarball_from_github(package, revision='master'):
         print stderr
         sys.exit(1)
 
-    # Make source tarball from the specified revision
+    # Make source tarball from the specified branch
     print 'Making "%s" from "%s"' % (source_tarball_name, clone_directory)
     command = ('git', '--git-dir=' + clone_directory,
                'archive', '--prefix=' + source_dir_name + '/', '--output=' + source_tarball_name,
-               revision)
+               branch)
     (exit_status, stdout, stderr) = run_command(command)
     if exit_status != 0:
         print 'git archive failed with exit status %d' % exit_status
@@ -124,12 +132,18 @@ def create_image(config_filename):
         for rpm in glob.glob(os.path.join(svn_dir, 'osg-test-*.rpm')):
             shutil.copy(rpm, input_directory)
 
-        if 'testsource = trunk' in config_contents or \
-                'testsource = master' in config_contents:
+        tarballs = []
+        try:
+            # Clone osg-test from source
+            repo, branch = re.search(r'testsource = (.*)/(.*)', config_contents).groups()
+            tarballs.append(make_source_tarball_from_github('osg-test', repo, branch))
+            tarballs.append(make_source_tarball_from_github('osg-ca-generator'))
+        except AttributeError:
+            # user did not request osg-test from source i.e. install from yum repos instead
+            pass
+        for tarball_name in tarballs:
+            shutil.copy(tarball_name, input_directory)
 
-            for package in ['osg-test', 'osg-ca-generator']:
-                tarball_name = make_source_tarball_from_github(package)
-                shutil.copy(tarball_name, input_directory)
 
         os.mkdir(os.path.join(image_directory, 'output'))
 

--- a/create-io-images
+++ b/create-io-images
@@ -41,7 +41,7 @@ def make_source_tarball_from_github(package, repo='opensciencegrid', branch='mas
     # Clone the repo into a temporary directory
     temp_directory = tempfile.mkdtemp()
     clone_directory = os.path.join(temp_directory, source_dir_name + '.git')
-    command = ('git', 'clone', '--bare', '--branch', branch, 'https://github.com/%s/%s' % (repo, package), clone_directory)
+    command = ('git', 'clone', '--bare', 'https://github.com/%s/%s' % (repo, package), clone_directory)
     (exit_status, stdout, stderr) = run_command(command)
     if exit_status != 0:
         print 'git clone failed with exit status %d' % exit_status

--- a/create-io-images
+++ b/create-io-images
@@ -96,7 +96,7 @@ def create_image(config_filename):
         tarballs = []
         try:
             # Clone osg-test from source
-            repo, branch = re.search(r'testsource = (.*)/(.*)', config_contents).groups()
+            repo, branch = re.search(r'testsource = (.*):(.*)', config_contents).groups()
             tarballs.append(make_source_tarball_from_github('osg-test', repo, branch))
             tarballs.append(make_source_tarball_from_github('osg-ca-generator'))
         except AttributeError:

--- a/create-io-images
+++ b/create-io-images
@@ -67,45 +67,6 @@ def make_source_tarball_from_github(package, repo='opensciencegrid', branch='mas
     return source_tarball_name
 
 
-def make_source_tarball(package):
-    source_dir_name = package + '-trunk'
-    source_tarball_name = source_dir_name + '.tar.bz2'
-    # Return immediately if the source tarball seems to exist already
-    if os.path.exists(source_tarball_name):
-        return source_tarball_name
-
-    # Export OSG software package from trunk@HEAD into a temporary directory
-    temp_directory = tempfile.mkdtemp()
-    export_directory = os.path.join(temp_directory, source_dir_name)
-    command = ('svn', 'export', 'https://vdt.cs.wisc.edu/svn/software/' + package + '/trunk', export_directory)
-    (exit_status, stdout, stderr) = run_command(command)
-    if exit_status != 0:
-        print 'svn export failed with exit status %d' % exit_status
-        print stdout
-        print stderr
-        sys.exit(1)
-    svn_revision = re.search(r'^Exported revision (\d+)\.', stdout, re.MULTILINE).group(1)
-
-    # Write Subversion revision number into the export directory
-    revision_path = os.path.join(export_directory, 'svn-revision.txt')
-    f = open(revision_path, 'w')
-    f.write(package + ' source: svn trunk@' + svn_revision + '\n')
-    f.close()
-
-    # Make source tarball
-    print 'Making "%s" from "%s"' % (source_tarball_name, temp_directory)
-    command = ('tar', 'cjf', source_tarball_name, '--directory', temp_directory, source_dir_name)
-    (exit_status, stdout, stderr) = run_command(command)
-    if exit_status != 0:
-        print 'tar command failed with exit status %d' % exit_status
-        print stdout
-        print stderr
-        sys.exit(1)
-
-    # Clean up
-    shutil.rmtree(temp_directory)
-    return source_tarball_name
-
 def create_image(config_filename):
     f = open(config_filename, 'r')
     config_contents = f.read()

--- a/parameters.d/osg32.yaml
+++ b/parameters.d/osg32.yaml
@@ -7,9 +7,9 @@ platform:
   - sl_6_x86_64
 
 sources:
-  - opensciencegrid/master; 3.2; osg
-  - opensciencegrid/master; 3.2; osg-testing
-  - opensciencegrid/master; 3.2; osg > osg-testing
+  - opensciencegrid:master; 3.2; osg
+  - opensciencegrid:master; 3.2; osg-testing
+  - opensciencegrid:master; 3.2; osg > osg-testing
 
 packages:
   - All: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal]

--- a/parameters.d/osg32.yaml
+++ b/parameters.d/osg32.yaml
@@ -7,9 +7,9 @@ platform:
   - sl_6_x86_64
 
 sources:
-  - trunk; 3.2; osg
-  - trunk; 3.2; osg-testing
-  - trunk; 3.2; osg > osg-testing
+  - opensciencegrid/master; 3.2; osg
+  - opensciencegrid/master; 3.2; osg-testing
+  - opensciencegrid/master; 3.2; osg > osg-testing
 
 packages:
   - All: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal]

--- a/parameters.d/osg33-el6.yaml
+++ b/parameters.d/osg33-el6.yaml
@@ -4,13 +4,13 @@ platform:
   - sl_6_x86_64
 
 sources:
-  - trunk; 3.3; osg
-  - trunk; 3.3; osg-testing
-  - trunk; 3.3; osg > osg-testing
-  - trunk; 3.3; osg-testing, osg-upcoming-testing
-  - trunk; 3.3; osg > osg-testing, osg-upcoming-testing
-  - trunk; 3.2; osg > 3.3/osg
-  - trunk; 3.2; osg > 3.3/osg-testing
+  - opensciencegrid/master; 3.3; osg
+  - opensciencegrid/master; 3.3; osg-testing
+  - opensciencegrid/master; 3.3; osg > osg-testing
+  - opensciencegrid/master; 3.3; osg-testing, osg-upcoming-testing
+  - opensciencegrid/master; 3.3; osg > osg-testing, osg-upcoming-testing
+  - opensciencegrid/master; 3.2; osg > 3.3/osg
+  - opensciencegrid/master; 3.2; osg > 3.3/osg-testing
 
 packages:
   - All: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal]

--- a/parameters.d/osg33-el6.yaml
+++ b/parameters.d/osg33-el6.yaml
@@ -4,13 +4,13 @@ platform:
   - sl_6_x86_64
 
 sources:
-  - opensciencegrid/master; 3.3; osg
-  - opensciencegrid/master; 3.3; osg-testing
-  - opensciencegrid/master; 3.3; osg > osg-testing
-  - opensciencegrid/master; 3.3; osg-testing, osg-upcoming-testing
-  - opensciencegrid/master; 3.3; osg > osg-testing, osg-upcoming-testing
-  - opensciencegrid/master; 3.2; osg > 3.3/osg
-  - opensciencegrid/master; 3.2; osg > 3.3/osg-testing
+  - opensciencegrid:master; 3.3; osg
+  - opensciencegrid:master; 3.3; osg-testing
+  - opensciencegrid:master; 3.3; osg > osg-testing
+  - opensciencegrid:master; 3.3; osg-testing, osg-upcoming-testing
+  - opensciencegrid:master; 3.3; osg > osg-testing, osg-upcoming-testing
+  - opensciencegrid:master; 3.2; osg > 3.3/osg
+  - opensciencegrid:master; 3.2; osg > 3.3/osg-testing
 
 packages:
   - All: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal]

--- a/parameters.d/osg33-el7.yaml
+++ b/parameters.d/osg33-el7.yaml
@@ -4,11 +4,11 @@ platform:
   - sl_7_x86_64
 
 sources:
-  - trunk; 3.3; osg
-  - trunk; 3.3; osg-testing
-  - trunk; 3.3; osg > osg-testing
-  - trunk; 3.3; osg-testing, osg-upcoming-testing
-  - trunk; 3.3; osg > osg-testing, osg-upcoming-testing
+  - opensciencegrid/master; 3.3; osg
+  - opensciencegrid/master; 3.3; osg-testing
+  - opensciencegrid/master; 3.3; osg > osg-testing
+  - opensciencegrid/master; 3.3; osg-testing, osg-upcoming-testing
+  - opensciencegrid/master; 3.3; osg > osg-testing, osg-upcoming-testing
 
 packages:
   - All: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal]

--- a/parameters.d/osg33-el7.yaml
+++ b/parameters.d/osg33-el7.yaml
@@ -4,11 +4,11 @@ platform:
   - sl_7_x86_64
 
 sources:
-  - opensciencegrid/master; 3.3; osg
-  - opensciencegrid/master; 3.3; osg-testing
-  - opensciencegrid/master; 3.3; osg > osg-testing
-  - opensciencegrid/master; 3.3; osg-testing, osg-upcoming-testing
-  - opensciencegrid/master; 3.3; osg > osg-testing, osg-upcoming-testing
+  - opensciencegrid:master; 3.3; osg
+  - opensciencegrid:master; 3.3; osg-testing
+  - opensciencegrid:master; 3.3; osg > osg-testing
+  - opensciencegrid:master; 3.3; osg-testing, osg-upcoming-testing
+  - opensciencegrid:master; 3.3; osg > osg-testing, osg-upcoming-testing
 
 packages:
   - All: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal]

--- a/run-job
+++ b/run-job
@@ -115,15 +115,15 @@ if [ $? -ne 0 ]; then
 fi
 
 # Install osg-test and osg-ca-generator
-if [ -f $INPUT_DIR/osg-test-master.tar.gz ]; then
+if [ -f $INPUT_DIR/osg-test-git.tar.gz ]; then
     run_command_with_retries 8 yum -y install git
 
     for PACKAGE in 'osg-test' 'osg-ca-generator'; do
-        tarball=$INPUT_DIR/$PACKAGE-master.tar.gz
+        tarball=$INPUT_DIR/$PACKAGE-git.tar.gz
         tar xzf $tarball --directory /tmp
-        cd /tmp/$PACKAGE-master
+        cd /tmp/$PACKAGE-git
         make install DESTDIR=/
-        log_command printf "%s source: git master (%s)\n"  $PACKAGE  $(zcat $tarball | git get-tar-commit-id | cut -c 1-7)
+        log_command printf "%s source: git (%s)\n"  $PACKAGE  $(zcat $tarball | git get-tar-commit-id | cut -c 1-7)
     done
 else
     RPM_LOCATION=`ls -1 $INPUT_DIR/osg-test-*.el$os_major_version.noarch.rpm 2>/dev/null | tail -n 1`

--- a/vmu.py
+++ b/vmu.py
@@ -109,9 +109,10 @@ def canonical_src_string(sources):
     result = re.sub(r'osg-upcoming', 'Upcoming', result)
     result = re.sub(r'osg-upcoming-testing', 'Upcoming Testing', result)
     result = re.sub(r'osg', 'Release', result) # Must come after other repos
+    result = re.sub(r'(^\w*/\w*)(.*)', '\\2 (\\1)', result)
     result = re.sub(r';', '', result)
     result = re.sub(r'/', ' ', result)
+    result = re.sub(r'\((\w*) (\w*)\)', '(\\1/\\2)', result)
     result = re.sub(r',', ' + ', result)
     result = re.sub(r'^(\d+\.\d+)(.*-> )(?!\d)', '\\1\\2\\1 ', result) # Duplicate release series, when needed
-    result = re.sub(r'^trunk\s*(.*)$', '\\1 (TRUNK)', result)
-    return result
+    return result.strip()

--- a/vmu.py
+++ b/vmu.py
@@ -109,10 +109,9 @@ def canonical_src_string(sources):
     result = re.sub(r'osg-upcoming', 'Upcoming', result)
     result = re.sub(r'osg-upcoming-testing', 'Upcoming Testing', result)
     result = re.sub(r'osg', 'Release', result) # Must come after other repos
-    result = re.sub(r'(^\w*/\w*)(.*)', '\\2 (\\1)', result)
+    result = re.sub(r'(^\w*:\w*)(.*)', '\\2 (\\1)', result)
     result = re.sub(r';', '', result)
     result = re.sub(r'/', ' ', result)
-    result = re.sub(r'\((\w*) (\w*)\)', '(\\1/\\2)', result)
     result = re.sub(r',', ' + ', result)
     result = re.sub(r'^(\d+\.\d+)(.*-> )(?!\d)', '\\1\\2\\1 ', result) # Duplicate release series, when needed
     return result.strip()


### PR DESCRIPTION
Results here: http://vdt.cs.wisc.edu/tests/20160508-1644/results.html

* I thought about moving the repo and branch information into the dropdown where it lists the osg-test version but that would mess up the reporting in cases where users run some tests out of trunk and the rest via RPM.
* I could translate the `opensciencegrid/master` label to `osg/master` or something along those lines to clean up the headers a bit. 