### PR TITLE
Read default osg-test config from file for easier editing

### DIFF
--- a/generate-dag
+++ b/generate-dag
@@ -27,12 +27,9 @@ def generate_dag_fragment(serial, combo):
 
 def write_osg_test_configuration(serial, combo, directory):
     _, sources, packages = combo
-    contents = '[Config]\n'
-    contents += 'adduser = True\n'
-    contents += 'dumpout = True\n'
-    contents += 'verbose = True\n'
-    contents += 'timeout = 14400\n'  # 4 hours
-    contents += 'hostcert = True\n'
+    base_config = open('osg-test.conf', 'r')
+    contents = base_config.read() + '\n' # ensure newline in case user forgets it
+    base_config.close()
 
     sources_parts = re.split(r'\s*;\s*', sources)
     if len(sources_parts) == 3:

--- a/osg-run-tests
+++ b/osg-run-tests
@@ -71,7 +71,7 @@ safe_run git clone --quiet --depth 1 https://github.com/opensciencegrid/vm-test-
 cd $GIT_CHECKOUT_DIR
 safe_run cp -r \
     master-run.dag \
-    generate-dag.sub generate-dag parameters.d test-exceptions.yaml component-tags.yaml \
+    generate-dag.sub generate-dag osg-test.conf parameters.d test-exceptions.yaml component-tags.yaml \
     create-io-images.sub create-io-images \
     run-job osg-test.patch test-changes.patch osg-release.patch single-test-run.sub inner-dag.config \
     process-job-output extract-job-output analyze_job_output.py \

--- a/osg-test.conf
+++ b/osg-test.conf
@@ -1,6 +1,6 @@
 [Config]
-
 adduser = True
 dumpout = True
 verbose = True
-packages = osg-tested-internal
+timeout = 14400
+hostcert = True


### PR DESCRIPTION
Test results look good (two unrelated, transient errors): http://vdt.cs.wisc.edu/tests/20160531-1403/results.html

This makes it easier to set the upcoming 'cilogon' option from  [SOFTWARE-1863](https://jira.opensciencegrid.org/browse/SOFTWARE-1863).