### PR TITLE
Pylint isinstance() fix and accept dashes in branch names

### DIFF
--- a/generate-dag
+++ b/generate-dag
@@ -91,9 +91,9 @@ if __name__ == '__main__':
     for param_file in run_params:
         packages = []
         for package_set in param_file['packages']:
-            if type(package_set) is dict:
+            if isinstance(package_set, dict):
                 packages.append(package_set.values()[0])
-            elif type(package_set) is list:
+            elif isinstance(package_set, list):
                 packages.append(package_set)
             else:
                 vmu.die("Got bad package list: '%s'" % package_set)

--- a/vmu.py
+++ b/vmu.py
@@ -109,7 +109,7 @@ def canonical_src_string(sources):
     result = re.sub(r'osg-upcoming', 'Upcoming', result)
     result = re.sub(r'osg-upcoming-testing', 'Upcoming Testing', result)
     result = re.sub(r'osg', 'Release', result) # Must come after other repos
-    result = re.sub(r'(^\w*:\w*)(.*)', '\\2 (\\1)', result)
+    result = re.sub(r'(^\w*:[\w-]*)(.*)', '\\2 (\\1)', result)
     result = re.sub(r';', '', result)
     result = re.sub(r'/', ' ', result)
     result = re.sub(r',', ' + ', result)


### PR DESCRIPTION
Mat had some strange looking reporting because we didn't expect dashes in branch names:

http://vdt.cs.wisc.edu/tests/20160621-1824/results.html

