### PR TITLE
Add back EL7 tests for BeStMan and VOMS

### DIFF
--- a/parameters.d/osg33-el7.yaml
+++ b/parameters.d/osg33-el7.yaml
@@ -20,4 +20,6 @@ packages:
                  globus-gram-job-manager-condor, globus-gram-job-manager-pbs-setup-seg]
   - HTCondor: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, condor.x86_64, osg-ce-condor, rsv]
   - GridFTP: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-gridftp, edg-mkgridmap, rsv]
+  - BeStMan: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-se-bestman, rsv]
+  - VOMS: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-voms, rsv]
   - GUMS: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-gums, rsv]


### PR DESCRIPTION
We've released BeStMan, and we have new VOMS tests that work on EL7
(with the release of VOMS in testing), so we should start using them in
the nightlies.