### PR TITLE
Apply a git-made osg-release.patch with -p1

### DIFF
--- a/run-job
+++ b/run-job
@@ -150,7 +150,13 @@ fi
 log_command yum -y install patch --disablerepo=osg
 log_command patch --directory=/usr/sbin --input=$INPUT_DIR/osg-test.patch --strip=1
 log_command patch --directory=$python_lib_dir/site-packages --input=$INPUT_DIR/test-changes.patch --strip=1
-log_command patch --directory=/etc/yum.repos.d --input=$INPUT_DIR/osg-release.patch --strip=0
+if head -1 $INPUT_DIR/osg-release.patch | grep -qE '^From [0-9a-f]{40} '; then
+    # git made this patch, so strip off the 'a/' and 'b/' from the filenames
+    strip=1
+else
+    strip=0
+fi
+log_command patch --directory=/etc/yum.repos.d --input=$INPUT_DIR/osg-release.patch --strip=$strip
 
 # Debug RHEL
 grep 'Red Hat' /etc/redhat-release > /dev/null 2>&1


### PR DESCRIPTION
If git has been used to create a patch, all the old files start with `a/` and all the new files start with `b/`, so the patch needs to be applied with `-p1`. When applying `osg-release.patch`, check to see if the patch was made with Git (by looking at the file header), and if so, apply with `-p1`. Otherwise, apply with `-p0` (the previous behavior).
