### PR TITLE
Use new osg-tested-internal-gram package available in 3.3. Still need to

### DIFF
--- a/parameters.d/osg32-updates.yaml
+++ b/parameters.d/osg32-updates.yaml
@@ -1,5 +1,5 @@
 ###################
-# OSG 3.3 EL6 tests
+# OSG 3.2 to 3.3 update tests
 # File format documention:
 # https://twiki.opensciencegrid.org/bin/view/SoftwareTeam/TestRunsAsVMs
 ###################
@@ -14,12 +14,8 @@ sources:
   # Format:
   # [<Github account>:<branch of osg-test>;] <Initial OSG Version>; <Intial yum repo> [>] [<Update OSG Version>/][<Update yum repo>]
   ###################
-  - opensciencegrid:master; 3.3; osg
-  - opensciencegrid:master; 3.3; osg-testing
-  - opensciencegrid:master; 3.3; osg > osg-testing
-  - opensciencegrid:master; 3.3; osg, osg-upcoming
-  - opensciencegrid:master; 3.3; osg-testing, osg-upcoming-testing
-  - opensciencegrid:master; 3.3; osg > osg-testing, osg-upcoming-testing
+  - opensciencegrid:master; 3.2; osg > 3.3/osg
+  - opensciencegrid:master; 3.2; osg > 3.3/osg-testing
 
 packages:
   ###################
@@ -31,7 +27,11 @@ packages:
   #     Label: [Package Set]
   ###################
   - All: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal]
-  - All + GRAM: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal-gram]
+  # Explicitly add GRAM packages since they were dropped from osg-ce (SOFTWARE-2278, SOFTWARE-2291)
+  - All + GRAM (3.2): [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal,
+                      globus-gatekeeper, globus-gram-client-tools, globus-gram-job-manager, globus-gram-job-manager-fork,
+                      globus-gram-job-manager-fork-setup-poll, gratia-probe-gram, globus-gram-job-manager-scripts,
+                      globus-gram-job-manager-condor, globus-gram-job-manager-pbs-setup-seg]
   - HTCondor: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, condor.x86_64, osg-ce-condor, rsv]
   - GridFTP: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-gridftp, edg-mkgridmap, rsv]
   - BeStMan: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-se-bestman, rsv]

--- a/parameters.d/osg33-el7.yaml
+++ b/parameters.d/osg33-el7.yaml
@@ -31,11 +31,7 @@ packages:
   #     Label: [Package Set]
   ###################
   - All: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal]
-  # Explicitly add GRAM packages since they were dropped from osg-ce (SOFTWARE-2278, SOFTWARE-2291)
-  - All + GRAM: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal,
-                 globus-gatekeeper, globus-gram-client-tools, globus-gram-job-manager, globus-gram-job-manager-fork,
-                 globus-gram-job-manager-fork-setup-poll, gratia-probe-gram, globus-gram-job-manager-scripts,
-                 globus-gram-job-manager-condor, globus-gram-job-manager-pbs-setup-seg]
+  - All + GRAM: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal-gram]
   - HTCondor: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, condor.x86_64, osg-ce-condor, rsv]
   - GridFTP: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-gridftp, edg-mkgridmap, rsv]
   - BeStMan: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-se-bestman, rsv]


### PR DESCRIPTION
list all the GRAM packages in 3.2 -> 3.3 updates since it doesn't exist
in 3.2.