### PR TITLE
Remove test runs that have been restarted twice that would otherwise

### DIFF
--- a/single-test-run.sub
+++ b/single-test-run.sub
@@ -9,7 +9,8 @@ vm_no_output_vm         = false
 vm_vnc                  = true
 # osg-test timeout is 4h, give it a 4h buffer
 periodic_hold           = (time() - JobCurrentStartDate > 28800)
-periodic_release        = ( (HoldReasonCode==3) && (NumJobStarts < 2) ) || ( (HoldReasonCode == 6) && regexp("VMGAHP_ERR_INTERNAL", HoldReason) )
+periodic_release        = ( (HoldReasonCode == 3) && (NumJobStarts < 2) ) || ( (HoldReasonCode == 6) && regexp("VMGAHP_ERR_INTERNAL", HoldReason) )
+periodic_remove         = ( (JobStatus == 5) && (HoldReasonCode =?= 3) && (NumJobStarts >= 2) )
 
 request_disk            = 6GB
 requirements            = ((HasGluster == True) && (HasVirshDefaultNetwork =?= True))


### PR DESCRIPTION
remain held due to 724fcc5. 733466d/SOFTWARE-2437 allows for robust handling of
removed jobs such that the entire run can continue.

This removes the need to baby sit test runs that run too long, which @timtheisen can attest to doing the other weekend.