### PR TITLE
Add example to 'sources' section of the params

### DIFF
--- a/email-analysis
+++ b/email-analysis
@@ -12,7 +12,7 @@ RECIPIENTS = (
     'Carl Edquist <edquist@cs.wisc.edu>',
     'Edgar Fajardo <emfajard@ucsd.edu>',
     'Jose Caballero <jcaballero@bnl.gov>',
-    'Martin Kandes <mkandes@sdsc.edu>'
+    'Martin Kandes <mkandes@sdsc.edu>',
     'Mat Selmeci <matyas@cs.wisc.edu>',
     'Suchandra Thapa <sthapa@ci.uchicago.edu>',
     'Tim Cartwright <cat@cs.wisc.edu>',

--- a/parameters.d/osg32-updates.yaml
+++ b/parameters.d/osg32-updates.yaml
@@ -12,7 +12,10 @@ platform:
 sources:
   ###################
   # Format:
-  # [<Github account>:<branch of osg-test>;] <Initial OSG Version>; <Intial yum repo> [>] [<Update OSG Version>/][<Update yum repo>]
+  # [<Github account>:<osg-test branch>;] <OSG ver>; <REPO 1, REPO 2...REPO N> [> <Update OSG ver>/<Update REPO 1, REPO 2...REPO N>]
+  # Example:
+  # Run osg-test with packages from 3.2-release and 3.2-testing that are then upgraded to 3.3-testing and 3-3-upcoming-testing:
+  # 3.2; osg, osg-testing > 3.3/osg-testing, osg-upcoming-testing
   ###################
   - opensciencegrid:master; 3.2; osg > 3.3/osg
   - opensciencegrid:master; 3.2; osg > 3.3/osg-testing

--- a/parameters.d/osg33-el6.yaml
+++ b/parameters.d/osg33-el6.yaml
@@ -12,7 +12,10 @@ platform:
 sources:
   ###################
   # Format:
-  # [<Github account>:<branch of osg-test>;] <Initial OSG Version>; <Intial yum repo> [>] [<Update OSG Version>/][<Update yum repo>]
+  # [<Github account>:<osg-test branch>;] <OSG ver>; <REPO 1, REPO 2...REPO N> [> <Update OSG ver>/<Update REPO 1, REPO 2...REPO N>]
+  # Example:
+  # Run osg-test with packages from 3.2-release and 3.2-testing that are then upgraded to 3.3-testing and 3-3-upcoming-testing:
+  # 3.2; osg, osg-testing > 3.3/osg-testing, osg-upcoming-testing
   ###################
   - opensciencegrid:master; 3.3; osg
   - opensciencegrid:master; 3.3; osg-testing

--- a/parameters.d/osg33-el7.yaml
+++ b/parameters.d/osg33-el7.yaml
@@ -12,7 +12,10 @@ platform:
 sources:
   ###################
   # Format:
-  # [<Github account>:<branch of osg-test>;] <Initial OSG Version>; <Intial yum repo> [>] [<Update OSG Version>/][<Update yum repo>]
+  # [<Github account>:<osg-test branch>;] <OSG ver>; <REPO 1, REPO 2...REPO N> [> <Update OSG ver>/<Update REPO 1, REPO 2...REPO N>]
+  # Example:
+  # Run osg-test with packages from 3.2-release and 3.2-testing that are then upgraded to 3.3-testing and 3-3-upcoming-testing:
+  # 3.2; osg, osg-testing > 3.3/osg-testing, osg-upcoming-testing
   ###################
   - opensciencegrid:master; 3.3; osg
   - opensciencegrid:master; 3.3; osg-testing


### PR DESCRIPTION
The formatting comment wasn't clear on specifying multiple repos on
upgrade. Added an example for the case with the most confusion.