### PR TITLE
Add ability to enable SELinux for specific package sets (SOFTWARE-2552)

### DIFF
--- a/analyze-test-run
+++ b/analyze-test-run
@@ -93,7 +93,7 @@ yaml_file.close()
 runs = yaml.load(yaml_contents)
 combined_param_path = os.path.join(run_directory, 'parameters.d')
 run_params = vmu.load_run_params(combined_param_path)
-package_mapping = vmu.pkg_mapping(run_params)
+PACKAGE_MAPPING = vmu.package_mapping(vmu.flatten_run_params(run_params))
 
 # Report on one run at a time
 total_jobs = 0
@@ -108,7 +108,7 @@ for run in runs:
     if status == 1:
         jobs_died += 1
     tally_run_results(results_by_os, vmu.canonical_os_string(run['os_release']), status)
-    tally_run_results(results_by_pkg, vmu.canonical_pkg_string(run['param_packages'], package_mapping), status)
+    tally_run_results(results_by_pkg, PACKAGE_MAPPING[run['param_packages']], status)
     tally_run_results(results_by_src, vmu.canonical_src_string(run['param_sources']), status)
 
 print_tallied_results(results_by_os, 'OS Release')
@@ -123,7 +123,8 @@ if len(deaths_by_host) > 0:
     print >> sys.stderr, 'Subject: VM universe failures for OSG tests on %s' % (time.strftime('%Y-%m-%d'))
     print >> sys.stderr
 
-    paragraph = 'The OSG Software team runs automated tests in VM universe every morning.  The following jobs failed today, for the reasons shown below.  The jobs are grouped by hypervisor host.'
+    paragraph = '''The OSG Software team runs automated tests in VM universe every morning.  The following jobs failed
+    today, for the reasons shown below.  The jobs are grouped by hypervisor host.'''
     print >> sys.stderr, textwrap.fill(paragraph, 75)
     print >> sys.stderr
 

--- a/analyze_job_output.py
+++ b/analyze_job_output.py
@@ -205,7 +205,8 @@ if __name__ == '__main__':
     conf_file = read_file(conf_file_name)
     data['param_sources'] = re_extract(r'^sources\s*=\s*(.*)$', conf_file, re.MULTILINE, group=1)
     data['param_packages'] = re_extract(r'^packages\s*=\s*(.*)$', conf_file, re.MULTILINE, group=1)
-    
+    data['selinux'] = re_extract(r'^selinux\s*=\s*(.*)$', conf_file, re.MULTILINE, group=1)
+
     # Read free size left in the IO image
     io_free_size_file = os.path.join(test_run_dir, 'io_free_size')
     data['io_free_size'] = read_file(io_free_size_file)

--- a/generate-dag
+++ b/generate-dag
@@ -85,7 +85,7 @@ if __name__ == '__main__':
 
     # Check if nightly
     with open('run_label', 'r') as f:
-        NIGHTLY = f.read().strip() == 'nightly'
+        nightly = f.read().strip() == 'nightly'
 
     # Start DAG file
     dag_contents = '# osg-test run generated %s\n' % (time.strftime('%Y-%m-%d %H:%M'))
@@ -100,7 +100,7 @@ if __name__ == '__main__':
                 run_combos.append(combo)
                 serial = '%03d' % (process)
                 dag_contents += generate_dag_fragment(serial, combo)
-                write_osg_test_configuration(serial, combo, test_run_directory, NIGHTLY)
+                write_osg_test_configuration(serial, combo, test_run_directory, nightly)
                 process += 1
 
     dag_contents += '\n'

--- a/generate-dag
+++ b/generate-dag
@@ -95,7 +95,7 @@ if __name__ == '__main__':
     process = 0
     run_combos = [] # keep track of all combos to remove dupes
     for param_file in run_params:
-        for combo in itertools.product(param_file['platform'], param_file['sources'], param_file['package_sets']):
+        for combo in itertools.product(param_file['platforms'], param_file['sources'], param_file['package_sets']):
             if combo not in run_combos:
                 run_combos.append(combo)
                 serial = '%03d' % (process)

--- a/generate-dag
+++ b/generate-dag
@@ -55,6 +55,7 @@ def write_osg_test_configuration(serial, combo, directory, nightly=False):
     contents += 'packages = %s\n' % (', '.join(package_set.packages))
     contents += 'series = %s\n' % (release_series)
     contents += 'sources = %s\n' % (sources)
+    contents += 'selinux = %s\n' % package_set.selinux
     contents += 'nightly = %s\n' % nightly
 
     vmu.write_file(contents, os.path.join(directory, 'osg-test-%s.conf' % (serial)))

--- a/generate-dag
+++ b/generate-dag
@@ -9,24 +9,23 @@ import time
 import vmu
 
 def generate_dag_fragment(serial, combo):
-    platform, sources, packages = combo
+    platform, sources, package_set = combo
     node_name = 'TestRun' + serial
 
     priority = 0
-    if 'osg-tested-internal' in packages:
+    if 'osg-tested-internal' in package_set.packages:
         priority = 1
 
     contents = '\n'
-    contents += '# Node %s: %s - %s - %s\n' % (serial, platform, sources, ', '.join(packages))
+    contents += '# Node %s: %s - %s - %s\n' % (serial, platform, sources, ', '.join(package_set.packages))
     contents += 'JOB %s single-test-run.sub\n' % (node_name)
     contents += 'VARS %s serial="%s" platform="%s" jobpriority="%d"\n' % (node_name, serial, platform, priority)
     contents += 'SCRIPT POST %s process-job-output %s $JOBID\n' % (node_name, serial)
-    if 'osg-tested-internal' in packages:
-        contents += 'PRIORITY %s %d\n' % (node_name, priority)
+    contents += 'PRIORITY %s %d\n' % (node_name, priority)
     return contents
 
-def write_osg_test_configuration(serial, combo, directory):
-    _, sources, packages = combo
+def write_osg_test_configuration(serial, combo, directory, nightly=False):
+    _, sources, package_set = combo
     base_config = open('osg-test.conf', 'r')
     contents = base_config.read() + '\n' # ensure newline in case user forgets it
     base_config.close()
@@ -52,11 +51,11 @@ def write_osg_test_configuration(serial, combo, directory):
             contents += 'updaterelease = %s\n' % (update_parts[0])
             if update_parts[1] != 'osg':
                 contents += 'updaterepos = %s\n' % (update_parts[1])
-    contents += 'packages = %s\n' % (', '.join(packages))
+
+    contents += 'packages = %s\n' % (', '.join(package_set.packages))
     contents += 'series = %s\n' % (release_series)
     contents += 'sources = %s\n' % (sources)
-    if NIGHTLY:
-            contents += 'nightly = True\n'
+    contents += 'nightly = %s\n' % nightly
 
     vmu.write_file(contents, os.path.join(directory, 'osg-test-%s.conf' % (serial)))
 
@@ -78,14 +77,13 @@ if __name__ == '__main__':
         vmu.die('%s: parameter directory "%s" does not exist' % (script_name, param_dir))
 
     run_params = vmu.load_run_params(param_dir)
-    vmu.pkg_mapping(run_params) # verify uniqueness of package sets + labels
-    
+    vmu.flatten_run_params(run_params) # verify uniqueness of package sets + labels
+
     # Set up test run directory
     test_run_directory = os.getcwd()
 
     # Check if nightly
     with open('run_label', 'r') as f:
-        global NIGHTLY
         NIGHTLY = f.read().strip() == 'nightly'
 
     # Start DAG file
@@ -96,21 +94,12 @@ if __name__ == '__main__':
     process = 0
     run_combos = [] # keep track of all combos to remove dupes
     for param_file in run_params:
-        packages = []
-        for package_set in param_file['packages']:
-            if isinstance(package_set, dict):
-                packages.append(package_set.values()[0])
-            elif isinstance(package_set, list):
-                packages.append(package_set)
-            else:
-                vmu.die("Got bad package list: '%s'" % package_set)
-
-        for combo in itertools.product(param_file['platform'], param_file['sources'], packages):
+        for combo in itertools.product(param_file['platform'], param_file['sources'], param_file['package_sets']):
             if combo not in run_combos:
                 run_combos.append(combo)
                 serial = '%03d' % (process)
                 dag_contents += generate_dag_fragment(serial, combo)
-                write_osg_test_configuration(serial, combo, test_run_directory)
+                write_osg_test_configuration(serial, combo, test_run_directory, NIGHTLY)
                 process += 1
 
     dag_contents += '\n'

--- a/parameters.d/osg32-updates.yaml
+++ b/parameters.d/osg32-updates.yaml
@@ -4,7 +4,7 @@
 # https://twiki.opensciencegrid.org/bin/view/SoftwareTeam/TestRunsAsVMs
 ###################
 
-platform:
+platforms:
   - centos_6_x86_64
   - rhel_6_x86_64
   - sl_6_x86_64

--- a/parameters.d/osg32-updates.yaml
+++ b/parameters.d/osg32-updates.yaml
@@ -20,23 +20,66 @@ sources:
   - opensciencegrid:master; 3.2; osg > 3.3/osg
   - opensciencegrid:master; 3.2; osg > 3.3/osg-testing
 
-packages:
-  ###################
-  # i.  If you are testing any java components, you should pre-install the
-  #     necessary java packages by prepending any package lists with the java
-  #     packages
-  # ii. Package sets can take labels that will be reflected in the test result
-  #     reporting. This can be specified with the following format:
-  #     Label: [Package Set]
-  ###################
-  - All: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal]
+package_sets:
+  #### Required ####
+  # label - used for reporting, should be consistent across param files
+  # packages - list of packages to install in the test run
+  #### Optional ####
+  # selinux - enable SELinux for the package set, otherwise Permissive mode (default: False)
+  # osg_java - Pre-install OSG java packages (default: True)
+  ##################
+  - label: All
+    selinux: False
+    osg_java: True
+    packages:
+      - osg-tested-internal
   # Explicitly add GRAM packages since they were dropped from osg-ce (SOFTWARE-2278, SOFTWARE-2291)
-  - All + GRAM (3.2): [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal,
-                      globus-gatekeeper, globus-gram-client-tools, globus-gram-job-manager, globus-gram-job-manager-fork,
-                      globus-gram-job-manager-fork-setup-poll, gratia-probe-gram, globus-gram-job-manager-scripts,
-                      globus-gram-job-manager-condor, globus-gram-job-manager-pbs-setup-seg]
-  - HTCondor: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, condor.x86_64, osg-ce-condor, rsv]
-  - GridFTP: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-gridftp, edg-mkgridmap, rsv]
-  - BeStMan: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-se-bestman, rsv]
-  - VOMS: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-voms, rsv]
-  - GUMS: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-gums, rsv]
+  - label: All + GRAM (3.2)
+    selinux: False
+    osg_java: True
+    packages:
+      - osg-tested-internal
+      - globus-gatekeeper
+      - globus-gram-client-tools
+      - globus-gram-job-manager
+      - globus-gram-job-manager-fork
+      - globus-gram-job-manager-fork-setup-poll
+      - gratia-probe-gram
+      - globus-gram-job-manager-scripts
+      - globus-gram-job-manager-condor
+      - globus-gram-job-manager-pbs-setup-seg
+  - label: HTCondor
+    selinux: False
+    osg_java: True
+    packages:
+      - condor.x86_64
+      - osg-ce-condor
+      - rsv
+  - label: GridFTP
+    selinux: True
+    osg_java: True
+    packages:
+      - java-1.7.0-openjdk-devel
+      - osg-java7-compat
+      - osg-java7-devel-compat
+      - osg-gridftp
+      - edg-mkgridmap
+      - rsv
+  - label: BeStMan
+    selinux: False
+    osg_java: True
+    packages:
+      - osg-se-bestman
+      - rsv
+  - label: VOMS
+    selinux: False
+    osg_java: True
+    packages:
+      - osg-voms
+      - rsv
+  - label: GUMS
+    selinux: False
+    osg_java: True
+    packages:
+      - osg-gums
+      - rsv

--- a/parameters.d/osg32-updates.yaml
+++ b/parameters.d/osg32-updates.yaml
@@ -59,9 +59,6 @@ package_sets:
     selinux: True
     osg_java: True
     packages:
-      - java-1.7.0-openjdk-devel
-      - osg-java7-compat
-      - osg-java7-devel-compat
       - osg-gridftp
       - edg-mkgridmap
       - rsv

--- a/parameters.d/osg33-el6.yaml
+++ b/parameters.d/osg33-el6.yaml
@@ -4,7 +4,7 @@
 # https://twiki.opensciencegrid.org/bin/view/SoftwareTeam/TestRunsAsVMs
 ###################
 
-platform:
+platforms:
   - centos_6_x86_64
   - rhel_6_x86_64
   - sl_6_x86_64

--- a/parameters.d/osg33-el6.yaml
+++ b/parameters.d/osg33-el6.yaml
@@ -54,9 +54,6 @@ package_sets:
     selinux: True
     osg_java: True
     packages:
-      - java-1.7.0-openjdk-devel
-      - osg-java7-compat
-      - osg-java7-devel-compat
       - osg-gridftp
       - edg-mkgridmap
       - rsv

--- a/parameters.d/osg33-el6.yaml
+++ b/parameters.d/osg33-el6.yaml
@@ -24,19 +24,57 @@ sources:
   - opensciencegrid:master; 3.3; osg-testing, osg-upcoming-testing
   - opensciencegrid:master; 3.3; osg > osg-testing, osg-upcoming-testing
 
-packages:
-  ###################
-  # i.  If you are testing any java components, you should pre-install the
-  #     necessary java packages by prepending any package lists with the java
-  #     packages
-  # ii. Package sets can take labels that will be reflected in the test result
-  #     reporting. This can be specified with the following format:
-  #     Label: [Package Set]
-  ###################
-  - All: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal]
-  - All + GRAM: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal-gram]
-  - HTCondor: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, condor.x86_64, osg-ce-condor, rsv]
-  - GridFTP: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-gridftp, edg-mkgridmap, rsv]
-  - BeStMan: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-se-bestman, rsv]
-  - VOMS: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-voms, rsv]
-  - GUMS: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-gums, rsv]
+package_sets:
+  #### Required ####
+  # label - used for reporting, should be consistent across param files
+  # packages - list of packages to install in the test run
+  #### Optional ####
+  # selinux - enable SELinux for the package set, otherwise Permissive mode (default: False)
+  # osg_java - Pre-install OSG java packages (default: True)
+  ##################
+  - label: All
+    selinux: False
+    osg_java: True
+    packages:
+      - osg-tested-internal
+  # Explicitly add GRAM packages since they were dropped from osg-ce (SOFTWARE-2278, SOFTWARE-2291)
+  - label: All + GRAM
+    selinux: False
+    osg_java: True
+    packages:
+      - osg-tested-internal-gram
+  - label: HTCondor
+    selinux: False
+    osg_java: True
+    packages:
+      - condor.x86_64
+      - osg-ce-condor
+      - rsv
+  - label: GridFTP
+    selinux: True
+    osg_java: True
+    packages:
+      - java-1.7.0-openjdk-devel
+      - osg-java7-compat
+      - osg-java7-devel-compat
+      - osg-gridftp
+      - edg-mkgridmap
+      - rsv
+  - label: BeStMan
+    selinux: False
+    osg_java: True
+    packages:
+      - osg-se-bestman
+      - rsv
+  - label: VOMS
+    selinux: False
+    osg_java: True
+    packages:
+      - osg-voms
+      - rsv
+  - label: GUMS
+    selinux: False
+    osg_java: True
+    packages:
+      - osg-gums
+      - rsv

--- a/parameters.d/osg33-el7.yaml
+++ b/parameters.d/osg33-el7.yaml
@@ -4,7 +4,7 @@
 # https://twiki.opensciencegrid.org/bin/view/SoftwareTeam/TestRunsAsVMs
 ###################
 
-platform:
+platforms:
   - centos_7_x86_64
   - rhel_7_x86_64
   - sl_7_x86_64

--- a/parameters.d/osg33-el7.yaml
+++ b/parameters.d/osg33-el7.yaml
@@ -54,9 +54,6 @@ package_sets:
     selinux: True
     osg_java: True
     packages:
-      - java-1.7.0-openjdk-devel
-      - osg-java7-compat
-      - osg-java7-devel-compat
       - osg-gridftp
       - edg-mkgridmap
       - rsv

--- a/parameters.d/osg33-el7.yaml
+++ b/parameters.d/osg33-el7.yaml
@@ -24,19 +24,57 @@ sources:
   - opensciencegrid:master; 3.3; osg-testing, osg-upcoming-testing
   - opensciencegrid:master; 3.3; osg > osg-testing, osg-upcoming-testing
 
-packages:
-  ###################
-  # i.  If you are testing any java components, you should pre-install the
-  #     necessary java packages by prepending any package lists with the java
-  #     packages
-  # ii. Package sets can take labels that will be reflected in the test result
-  #     reporting. This can be specified with the following format:
-  #     Label: [Package Set]
-  ###################
-  - All: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal]
-  - All + GRAM: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-tested-internal-gram]
-  - HTCondor: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, condor.x86_64, osg-ce-condor, rsv]
-  - GridFTP: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-gridftp, edg-mkgridmap, rsv]
-  - BeStMan: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-se-bestman, rsv]
-  - VOMS: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-voms, rsv]
-  - GUMS: [java-1.7.0-openjdk-devel, osg-java7-compat, osg-java7-devel-compat, osg-gums, rsv]
+package_sets:
+  #### Required ####
+  # label - used for reporting, should be consistent across param files
+  # packages - list of packages to install in the test run
+  #### Optional ####
+  # selinux - enable SELinux for the package set, otherwise Permissive mode (default: False)
+  # osg_java - Pre-install OSG java packages (default: True)
+  ##################
+  - label: All
+    selinux: False
+    osg_java: True
+    packages:
+      - osg-tested-internal
+  # Explicitly add GRAM packages since they were dropped from osg-ce (SOFTWARE-2278, SOFTWARE-2291)
+  - label: All + GRAM
+    selinux: False
+    osg_java: True
+    packages:
+      - osg-tested-internal-gram
+  - label: HTCondor
+    selinux: False
+    osg_java: True
+    packages:
+      - condor.x86_64
+      - osg-ce-condor
+      - rsv
+  - label: GridFTP
+    selinux: True
+    osg_java: True
+    packages:
+      - java-1.7.0-openjdk-devel
+      - osg-java7-compat
+      - osg-java7-devel-compat
+      - osg-gridftp
+      - edg-mkgridmap
+      - rsv
+  - label: BeStMan
+    selinux: False
+    osg_java: True
+    packages:
+      - osg-se-bestman
+      - rsv
+  - label: VOMS
+    selinux: False
+    osg_java: True
+    packages:
+      - osg-voms
+      - rsv
+  - label: GUMS
+    selinux: False
+    osg_java: True
+    packages:
+      - osg-gums
+      - rsv

--- a/tests/test_vmu.py
+++ b/tests/test_vmu.py
@@ -110,7 +110,7 @@ class TestLoadRunParams(TestVmu):
         mock_glob = patch_glob.start()
         mock_glob.return_value = [1]
 
-        params = {'platform': ['foo'], 'sources': ['bar'], 'package_sets': [{'label': 'foo', 'packages': [1, 2, 3]}]}
+        params = {'platforms': ['foo'], 'sources': ['bar'], 'package_sets': [{'label': 'foo', 'packages': [1, 2, 3]}]}
         params.pop(section, None)
 
         patch_yaml_load = mock.patch('vmu.yaml.load')
@@ -127,8 +127,8 @@ class TestLoadRunParams(TestVmu):
         mock_glob.return_value = []
         self.assertRaises(vmu.ParamError, vmu.load_run_params, self.param_dir)
 
-    def test_no_platform_section(self):
-        self.missing_param_section('platform')
+    def test_no_platforms_section(self):
+        self.missing_param_section('platforms')
 
     def test_no_sources_section(self):
         self.missing_param_section('sources')
@@ -148,7 +148,7 @@ class TestFlattenParams(TestVmu):
 
     def test_single_file(self):
         run_params = [
-            {'platform': ['foo'],
+            {'platforms': ['foo'],
              'sources': ['bar', 'foo'],
              'package_sets':
              [
@@ -175,24 +175,24 @@ class TestFlattenParams(TestVmu):
         list1 = ['foo', 'bar']
         list2 = ['baz']
         run_params = [
-            {'platform': list1},
-            {'platform': list1},
-            {'platform': list2},
+            {'platforms': list1},
+            {'platforms': list1},
+            {'platforms': list2},
         ]
         expected = list1 + list2
-        self.assertEqualWithResults(expected, vmu.flatten_run_params(run_params)['platform'],
+        self.assertEqualWithResults(expected, vmu.flatten_run_params(run_params)['platforms'],
                                     "Failed to combine multiple files with single 'platforms' section sections")
 
     def test_multi_file_multi_param(self):
         run_params = [
-            {'platform': ['foo'],
+            {'platforms': ['foo'],
              'sources': ['foo', 'bar'],
              'package_sets':
              [
                  vmu.PackageSet('foo', ['foo', 'bar'])
              ]
             },
-            {'platform': ['foo'],
+            {'platforms': ['foo'],
              'sources': ['foo', 'bar'],
              'package_sets':
              [

--- a/tests/test_vmu.py
+++ b/tests/test_vmu.py
@@ -68,14 +68,14 @@ class TestPackageSet(TestVmu):
 
     def test_sorting(self):
         unsorted_pkgs = [vmu.PackageSet('All + GRAM', [1]),
-                vmu.PackageSet('GridFTP', [1]),
-                vmu.PackageSet('VOMS', [1]),
-                vmu.PackageSet('All + GRAM (3.2)', [1]),
-                vmu.PackageSet('All', [1]),
-                vmu.PackageSet('HTCondor', [1]),
-                vmu.PackageSet('GUMS', [1]),
-                vmu.PackageSet('BeStMan', [1]),
-                vmu.PackageSet('foo', [1])]
+                         vmu.PackageSet('GridFTP', [1]),
+                         vmu.PackageSet('VOMS', [1]),
+                         vmu.PackageSet('All + GRAM (3.2)', [1]),
+                         vmu.PackageSet('All', [1]),
+                         vmu.PackageSet('HTCondor', [1]),
+                         vmu.PackageSet('GUMS', [1]),
+                         vmu.PackageSet('BeStMan', [1]),
+                         vmu.PackageSet('foo', [1])]
         unsorted_pkgs.sort()
         self.assertEqualWithResults(vmu.PackageSet.LABEL_ORDER + ['foo'],
                                     [x.label for x in unsorted_pkgs],
@@ -89,11 +89,14 @@ class TestPackageSet(TestVmu):
 
     def test_hashable(self):
         selinux_enabled = vmu.PackageSet('foo', [1, 2, 3], True, True)
+        selinux_disabled = vmu.PackageSet('foo', [1, 2, 3], False, True)
+        different_packages = vmu.PackageSet('bar', [4, 5, 6], True, True)
         self.assert_(set([selinux_enabled]),
                      'PackageSet.__hash__() broken')
-        self.assertEqualWithResults(set([selinux_enabled]),
-                                    set([selinux_enabled, selinux_enabled]),
-                                    'PackageSet hash equality')
+        self.assertEqual(selinux_enabled.__hash__(),
+                         selinux_disabled.__hash__(),
+                         'PackageSet hash equality, SELinux agnostic')
+        self.assertNotEqual(selinux_enabled.__hash__(), different_packages.__hash__(), 'PackageSet hash inequality')
 
     def test_from_dict(self):
         pkg_set_dict = {'label': 'gums', 'packages': ['osg-gums', 'rsv'], 'selinux': False, 'osg_java': True}

--- a/tests/test_vmu.py
+++ b/tests/test_vmu.py
@@ -50,21 +50,22 @@ class TestPackageSet(TestVmu):
         self.assertRaises(vmu.ParamError, vmu.PackageSet.__eq__,
                           vmu.PackageSet('foo', [1, 2, 3], True, False),
                           vmu.PackageSet('bar', [1, 2, 3], False, False))
+        self.assertRaises(vmu.ParamError, vmu.PackageSet.__eq__,
+                          vmu.PackageSet('foo', [1, 2, 3], True, False),
+                          vmu.PackageSet('foo', [4, 5, 6], False, False))
 
     def test_inequality(self):
         self.assertNotEqualWithResults(vmu.PackageSet('foo', [1, 2, 3]),
                                        vmu.PackageSet('bar', [4, 5, 6]),
                                        'PackageSet packages inequality broken')
-        self.assertNotEqualWithResults(vmu.PackageSet('foo', [1, 2, 3]),
-                                       vmu.PackageSet('foo', [4, 5, 6]),
-                                       'PackageSet packages inequality broken')
-        self.assertNotEqualWithResults(vmu.PackageSet('foo', [1, 2, 3], java=True),
-                                       vmu.PackageSet('foo', [1, 2, 3], java=False),
-                                       'PackageSet java inequality broken')
+
         # Test mismatched tags
-        self.assertRaises(vmu.ParamError, vmu.PackageSet.__eq__,
+        self.assertRaises(vmu.ParamError, vmu.PackageSet.__ne__,
                           vmu.PackageSet('foo', [1, 2, 3], True, False),
                           vmu.PackageSet('bar', [1, 2, 3], False, False))
+        self.assertRaises(vmu.ParamError, vmu.PackageSet.__ne__,
+                          vmu.PackageSet('foo', [1, 2, 3], True, False),
+                          vmu.PackageSet('foo', [4, 5, 6], False, False))
 
     def test_sorting(self):
         unsorted_pkgs = [vmu.PackageSet('All + GRAM', [1]),

--- a/tests/test_vmu.py
+++ b/tests/test_vmu.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python
+# python -m unittest -v test_vmu[.TestClass][.test_function]
+
+#pylint: disable=C0301
+#pylint: disable=R0904
+
+import copy
+import os
+import sys
+import unittest
+
+PATHNAME = os.path.realpath('../')
+sys.path.insert(0, PATHNAME)
+
+import vmu
+
+def results_msg(expected, actual, msg):
+    divider = '='*70 + '\n'
+    return '%s\n' % msg + divider + \
+        'EXPECTED:\n%s\n' % str(expected) + divider + \
+        'ACTUAL:\n%s\n' % str(actual)
+
+class TestVmu(unittest.TestCase):
+
+    def assertEqualWithResults(self, expected, actual, msg=None):
+        """Assert equality with pre-built failure message"""
+        self.assertEqual(expected, actual, results_msg(expected, actual, msg))
+
+    def assertNotEqualWithResults(self, expected, actual, msg=None):
+        """Assert inequality with pre-built failure message"""
+        self.assertNotEqual(expected, actual, results_msg(expected, actual, msg))
+
+class TestPackageSet(TestVmu):
+
+    def test_missing_label(self):
+        self.assertRaises(vmu.ParamError, vmu.PackageSet, '', [1, 2, 3])
+
+    def test_empty_packages(self):
+        self.assertRaises(vmu.ParamError, vmu.PackageSet, 'foo', [])
+
+    def test_equality(self):
+        self.assertEqualWithResults(vmu.PackageSet('foo', [1, 2, 3], True, False),
+                                    vmu.PackageSet('foo', [1, 2, 3], True, False),
+                                    'PackageSet label or packages equality broken')
+        self.assertEqualWithResults(vmu.PackageSet('foo', [1, 2, 3], True, False),
+                                    vmu.PackageSet('foo', [1, 2, 3], False, False),
+                                    'PackageSet SELinux equality broken')
+        # Test mismatched tags
+        self.assertRaises(vmu.ParamError, vmu.PackageSet.__eq__,
+                          vmu.PackageSet('foo', [1, 2, 3], True, False),
+                          vmu.PackageSet('bar', [1, 2, 3], False, False))
+
+    def test_inequality(self):
+        self.assertNotEqualWithResults(vmu.PackageSet('foo', [1, 2, 3]),
+                                       vmu.PackageSet('bar', [4, 5, 6]),
+                                       'PackageSet packages inequality broken')
+        self.assertNotEqualWithResults(vmu.PackageSet('foo', [1, 2, 3]),
+                                       vmu.PackageSet('foo', [4, 5, 6]),
+                                       'PackageSet packages inequality broken')
+        self.assertNotEqualWithResults(vmu.PackageSet('foo', [1, 2, 3], java=True),
+                                       vmu.PackageSet('foo', [1, 2, 3], java=False),
+                                       'PackageSet java inequality broken')
+        # Test mismatched tags
+        self.assertRaises(vmu.ParamError, vmu.PackageSet.__eq__,
+                          vmu.PackageSet('foo', [1, 2, 3], True, False),
+                          vmu.PackageSet('bar', [1, 2, 3], False, False))
+
+    def test_sorting(self):
+        unsorted_pkgs = [vmu.PackageSet('All + GRAM', [1]),
+                vmu.PackageSet('GridFTP', [1]),
+                vmu.PackageSet('VOMS', [1]),
+                vmu.PackageSet('All + GRAM (3.2)', [1]),
+                vmu.PackageSet('All', [1]),
+                vmu.PackageSet('HTCondor', [1]),
+                vmu.PackageSet('GUMS', [1]),
+                vmu.PackageSet('BeStMan', [1]),
+                vmu.PackageSet('foo', [1])]
+        unsorted_pkgs.sort()
+        self.assertEqualWithResults(vmu.PackageSet.LABEL_ORDER + ['foo'],
+                                    [x.label for x in unsorted_pkgs],
+                                    'Unexpected sort order')
+
+    def test_defaults(self):
+        pkg_set = vmu.PackageSet('foo', [1, 2, 3])
+        self.assertEqual(pkg_set.selinux, vmu.PackageSet.SELINUX_DEFAULT, 'Failed to set SELinux default')
+        self.assertEqual(pkg_set.java, vmu.PackageSet.OSG_JAVA_DEFAULT, 'Failed to set OSG Java default')
+
+
+    def test_hashable(self):
+        selinux_enabled = vmu.PackageSet('foo', [1, 2, 3], True, True)
+        self.assert_(set([selinux_enabled]),
+                     'PackageSet.__hash__() broken')
+        self.assertEqualWithResults(set([selinux_enabled]),
+                                    set([selinux_enabled, selinux_enabled]),
+                                    'PackageSet hash equality')
+
+    def test_from_dict(self):
+        pkg_set_dict = {'label': 'gums', 'packages': ['osg-gums', 'rsv'], 'selinux': False, 'osg_java': True}
+        self.assertEqualWithResults(vmu.PackageSet.from_dict(pkg_set_dict),
+                                    vmu.PackageSet('gums', ['osg-gums', 'rsv'], False, True),
+                                    'Manually generated PackageSet differs from one generated from a dict')
+
+class TestFlattenParams(TestVmu):
+
+    def test_single_file(self):
+        run_params = [
+            {'platform': ['foo'],
+             'sources': ['bar', 'foo'],
+             'package_sets':
+             [
+                 vmu.PackageSet('foo', ['foo', 'bar'])
+             ]
+            }
+        ]
+        self.assertEqualWithResults(run_params[0], vmu.flatten_run_params(run_params),
+                                    'Unexpectedly modified single yaml file')
+
+    def test_mismatched_tags(self):
+        pkgs = ['foo', 'bar']
+        run_params = [
+            {'package_sets':
+             [
+                 vmu.PackageSet('foo', pkgs),
+                 vmu.PackageSet('bar', pkgs),
+             ]
+            }
+        ]
+        self.assertRaises(vmu.ParamError, vmu.flatten_run_params, run_params)
+
+    def test_multi_file_single_param(self):
+        list1 = ['foo', 'bar']
+        list2 = ['baz']
+        run_params = [
+            {'platform': list1},
+            {'platform': list1},
+            {'platform': list2},
+        ]
+        expected = list1 + list2
+        self.assertEqualWithResults(expected, vmu.flatten_run_params(run_params)['platform'],
+                                    "Failed to combine multiple files with single 'platforms' section sections")
+
+    def test_multi_file_multi_param(self):
+        run_params = [
+            {'platform': ['foo'],
+             'sources': ['foo', 'bar'],
+             'package_sets':
+             [
+                 vmu.PackageSet('foo', ['foo', 'bar'])
+             ]
+            },
+            {'platform': ['foo'],
+             'sources': ['foo', 'bar'],
+             'package_sets':
+             [
+                 vmu.PackageSet('foo', ['foo', 'bar'])
+             ]
+            }
+        ]
+        expected = copy.deepcopy(run_params).pop()
+        self.assertEqualWithResults(expected, vmu.flatten_run_params(run_params),
+                                    'Failed to flatten identical files')
+
+    def test_multi_file_multi_pkg_sets(self):
+        set1 = [vmu.PackageSet('All', ['osg-tested-internal']),
+                vmu.PackageSet('GridFTP', ['osg-gridftp'])]
+        set2 = set1 + [vmu.PackageSet('GUMS', ['osg-gums'])]
+
+        run_params = [{'package_sets': set1},
+                      {'package_sets': set2}]
+
+        self.assertEqualWithResults(set2, vmu.flatten_run_params(run_params)['package_sets'],
+                                    'Failed to combine multiple files with unique package sets')
+
+class TestPackageMapping(TestVmu):
+
+    foo_pkg_set = ['foo']
+    bar_pkg_set = ['bar', 'baz']
+    flat_params = {
+        'package_sets':
+        [
+            vmu.PackageSet('foo', foo_pkg_set, java=False),
+            vmu.PackageSet('bar', bar_pkg_set, java=False)
+        ]
+    }
+
+    def test_mapping(self):
+        expected = {', '.join(self.foo_pkg_set): 'foo', ', '.join(self.bar_pkg_set): 'bar'}
+        self.assertEqualWithResults(expected, vmu.package_mapping(self.flat_params),
+                                    'Bad mapping for simple case with single package set')
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/vmu-reporter
+++ b/vmu-reporter
@@ -78,7 +78,7 @@ def generate_table():
 
     # Get number of platforms per dver so we know the length of the dver columns
     num_el = {}
-    for platform in TABLE_LABELS['platform']:
+    for platform in TABLE_LABELS['platforms']:
         dver = platform[-1]
         try:
             num_el[dver] += 1
@@ -92,7 +92,7 @@ def generate_table():
 
     # Print out all the OS flavors
     os_row = Tag('tr')
-    for platform in TABLE_LABELS['platform']:
+    for platform in TABLE_LABELS['platforms']:
         os_row.append_new_tag('th').append(' ' + platform[:-1])
 
     header = Tag('thead').extend([dver_row, os_row])
@@ -125,7 +125,7 @@ def generate_table_body():
             # If no values in this row, skip it!
             empty_row = True
             rest_of_row = Tag('th', class_='yheader').append(secondary_sort_val)
-            for platform in TABLE_LABELS['platform']:
+            for platform in TABLE_LABELS['platforms']:
                 try:
                     if SORT_BY == 'release':
                         cell = generate_cell(sorted_tests[platform][primary_sort_val][secondary_sort_val])
@@ -291,7 +291,7 @@ if __name__ == "__main__":
     FLAT_PARAMS = vmu.flatten_run_params(params)
     PACKAGE_MAPPING = vmu.package_mapping(FLAT_PARAMS)
     TABLE_LABELS = {}
-    TABLE_LABELS['platform'] = sort_platforms_by_dver(FLAT_PARAMS['platform'])
+    TABLE_LABELS['platforms'] = sort_platforms_by_dver(FLAT_PARAMS['platforms'])
     TABLE_LABELS['packages'] = [x.label for x in FLAT_PARAMS['package_sets']]
     TABLE_LABELS['sources'] = [vmu.canonical_src_string(x) for x in FLAT_PARAMS['sources']]
 

--- a/vmu-reporter
+++ b/vmu-reporter
@@ -9,7 +9,6 @@ import vmu
 from taglib import Html, Tag
 from glob import glob
 
-global PACKAGE_MAPPING
 VMU_TESTS_URL = "http://vdt.cs.wisc.edu/tests/"
 OS_TRANSLATION = {'centos': 'CentOS', 'rhel': 'RHEL', 'sl': 'SL'}
 
@@ -51,7 +50,6 @@ def generate_header():
     legend_container = html.body.append_new_tag('p')
     for status in legend:
         legend_container.append_new_tag('span', class_='legend ' + status.lower()).append(status)
-    legend_container.append_new_tag('p').append('* = Java pre-installed')
     legend_container.append_new_tag('p').append('&#0153; = Yum timeout failure')
 
     return html
@@ -80,7 +78,7 @@ def generate_table():
 
     # Get number of platforms per dver so we know the length of the dver columns
     num_el = {}
-    for platform in TEST_PARAMS['platform']:
+    for platform in TABLE_LABELS['platform']:
         dver = platform[-1]
         try:
             num_el[dver] += 1
@@ -94,7 +92,7 @@ def generate_table():
 
     # Print out all the OS flavors
     os_row = Tag('tr')
-    for platform in TEST_PARAMS['platform']:
+    for platform in TABLE_LABELS['platform']:
         os_row.append_new_tag('th').append(' ' + platform[:-1])
 
     header = Tag('thead').extend([dver_row, os_row])
@@ -110,11 +108,11 @@ def generate_table_body():
     sorted_tests = sort_tests(yaml.load(yaml_data))
 
     if SORT_BY == 'release':
-        primary_sort_column = TEST_PARAMS['sources']
-        secondary_sort_column = TEST_PARAMS['packages']
+        primary_sort_column = TABLE_LABELS['sources']
+        secondary_sort_column = TABLE_LABELS['packages']
     elif SORT_BY == 'package':
-        primary_sort_column = TEST_PARAMS['packages']
-        secondary_sort_column = TEST_PARAMS['sources']
+        primary_sort_column = TABLE_LABELS['packages']
+        secondary_sort_column = TABLE_LABELS['sources']
 
     tbody = Tag('tbody')
     for primary_sort_val in primary_sort_column:
@@ -127,7 +125,7 @@ def generate_table_body():
             # If no values in this row, skip it!
             empty_row = True
             rest_of_row = Tag('th', class_='yheader').append(secondary_sort_val)
-            for platform in TEST_PARAMS['platform']:
+            for platform in TABLE_LABELS['platform']:
                 try:
                     if SORT_BY == 'release':
                         cell = generate_cell(sorted_tests[platform][primary_sort_val][secondary_sort_val])
@@ -243,7 +241,7 @@ def sort_tests(tests):
     for test in tests:
         platform = vmu.canonical_os_string(test['os_release'])
         src = vmu.canonical_src_string(test['param_sources'])
-        pkg = vmu.canonical_pkg_string(test['param_packages'], PACKAGE_MAPPING)
+        pkg = PACKAGE_MAPPING[test['param_packages']]
         try:
             sorted_tests[platform][src][pkg] = test
         except KeyError:
@@ -288,23 +286,13 @@ if __name__ == "__main__":
     # Read, sort, and translate test parameters
     param_dir = RUN_DIR + 'parameters.d'
     params = vmu.load_run_params(param_dir)
-    TEST_PARAMS = vmu.flatten_run_params(params)
-    TEST_PARAMS['platform'] = sort_platforms_by_dver(TEST_PARAMS['platform'])
+    FLAT_PARAMS = vmu.flatten_run_params(params)
+    PACKAGE_MAPPING = vmu.package_mapping(FLAT_PARAMS)
+    TABLE_LABELS = {}
+    TABLE_LABELS['platform'] = sort_platforms_by_dver(FLAT_PARAMS['platform'])
+    TABLE_LABELS['packages'] = [x.label for x in FLAT_PARAMS['package_sets']]
+    TABLE_LABELS['sources'] = [vmu.canonical_src_string(x) for x in FLAT_PARAMS['sources']]
 
-    translated_pkgs = list()
-    PACKAGE_MAPPING = vmu.pkg_mapping(params)
-    for package_set in TEST_PARAMS['packages']:
-        if type(package_set) is dict:
-            package_set = package_set.values()[0]
-        package_set = ', '.join(package_set)
-        translated_pkgs.append(vmu.canonical_pkg_string(package_set, PACKAGE_MAPPING))
-    TEST_PARAMS['packages'] = translated_pkgs
-
-    sources = list()
-    for source in TEST_PARAMS['sources']:
-        sources.append(vmu.canonical_src_string(source))
-    TEST_PARAMS['sources'] = sources
-    
     # Construct and print results
     HTML = generate_header()
     TABLE = generate_table()

--- a/vmu-reporter
+++ b/vmu-reporter
@@ -195,6 +195,8 @@ def generate_cell(run):
         test_log_path = glob('%soutput-%s/output/osg-test*.log' % (RUN_DIR, run['job_serial']))[0]
         test_log_filename = os.path.basename(test_log_path)
         link_location = '%s/%s' % (run_url_output_dir, test_log_filename)
+        link_text = "%s %s %s%s" % (run['tests_ok'], run['tests_ok_skip'], fail_count,
+                                    ' &#128274;' if run['selinux'] else '')
 
         try:
             status_regex = r'(install|update|timeout)\s*(yum_timeout)?'
@@ -203,9 +205,9 @@ def generate_cell(run):
                 link_text = status.upper() + '&#0153;'
             else:
                 link_text = status.upper()
-            link = Tag('a', href=link_location).append(link_text)
         except AttributeError:
-            link = Tag('a', href=link_location).append("%s %s %s" % (run['tests_ok'], run['tests_ok_skip'], fail_count))
+            pass
+        link = Tag('a', href=link_location).append(link_text)
     else:
         mouseover_text += '<b>Run Summary</b>: ' + run['run_summary']
         link_location = run_url_output_dir + '/run-job.log'

--- a/vmu.py
+++ b/vmu.py
@@ -33,7 +33,7 @@ def load_run_params(param_dir):
             # skip non-yaml files
             pass
         else:
-            if set(param_contents.iterkeys()) == set(['platforms', 'sources', 'package_sets']):
+            if set(param_contents.keys()) == set(['platforms', 'sources', 'package_sets']):
                 param_contents['package_sets'] = [PackageSet.from_dict(x) for x in param_contents['package_sets']]
                 run_params.append(param_contents)
     if not run_params:

--- a/vmu.py
+++ b/vmu.py
@@ -125,6 +125,7 @@ class PackageSet(object):
         self.selinux = selinux
         self.java = java
 
+        # FIXME: PackageSet is currently a misnomer since 'packages' are a list rather than a set
         if self.java:
             self.packages = ['java-1.7.0-openjdk-devel', 'osg-java7-compat', 'osg-java7-devel-compat'] + packages
         else:
@@ -162,7 +163,7 @@ class PackageSet(object):
         return hash(repr(self).replace('%s, ' % self.selinux, ''))
 
     def __repr__(self):
-        return str([self.label, self.selinux, self.packages])
+        return "PackageSet(label=%s, packages=%s, selinux=%s)" % (self.label, self.selinux, self.packages)
 
     @classmethod
     def from_dict(cls, pkg_set_dict):

--- a/vmu.py
+++ b/vmu.py
@@ -41,12 +41,19 @@ def load_run_params(param_dir):
     return run_params
 
 def flatten_run_params(params_list):
-    '''Combines multiple run parameters files into a single dictionary (eliminating duplicates)'''
-    primary = copy.deepcopy(params_list[0])
-    for param in primary.iterkeys():
-        for secondary in params_list[1:]:
-            primary[param] += [val for val in secondary[param] if val not in primary[param]]
-    return primary
+    '''Combines multiple run parameter files into a single dictionary eliminating duplicates in the 'platforms',
+    'sources', and 'package_sets' sections. Sorts the 'package_sets' section, leaving the others unsorted. '''
+    result = {'platform': [], 'sources': [], 'package_sets': []}
+    for param_file_contents in params_list:
+        for section in param_file_contents.iterkeys():
+            section_contents = param_file_contents[section]
+            for item in section_contents:
+                if item in result[section]:
+                    continue
+                result[section] += [item]
+            if section == 'package_sets':
+                result[section].sort()
+    return result
 
 def pkg_mapping(run_params):
     '''Takes a list of params (i.e. output of load_run_params) and extracts the unique packages and their labels, 

--- a/vmu.py
+++ b/vmu.py
@@ -55,32 +55,10 @@ def flatten_run_params(params_list):
                 result[section].sort()
     return result
 
-def pkg_mapping(run_params):
-    '''Takes a list of params (i.e. output of load_run_params) and extracts the unique packages and their labels, 
-    if any, returning a dictionary with strings of packages and labels as key/value pairs'''
-    mapping = {}
-    labels = {} # for verifying uniqueness of labels
-    flat_params = flatten_run_params(run_params)
-    for pkg_list in flat_params['packages']:
-        # Items in the 'packages' section can be dicts or lists (i.e. labeled or not)
-        if type(pkg_list) is dict:
-            label, pkg_list = pkg_list.items()[0]
-            pkg_list = ', '.join(pkg_list)
-        else:
-            continue
-        if mapping.has_key(pkg_list):
-            if mapping[pkg_list] == label:
-                continue
-            else:
-                die("ERROR: Two different labels ('%s', '%s') are being used to describe the same package set:\n"
-                    % (label, mapping[pkg_list]) + "[%s]" % pkg_list, code=2)
-        elif labels.has_key(label):
-            die("ERROR: The label '%s' describes two different package sets:\n" % label +
-                "[%s]\n[%s]" % (labels[label], pkg_list), code=2)
-        else:
-            mapping.update({pkg_list: label})
-            labels.update({label: pkg_list})
-    return mapping
+def package_mapping(flat_params):
+    '''Takes the unique parameters (i.e. the output from flatten_run_params) and returns a dictionary of stringified
+    lists of packages as keys and their labels as values'''
+    return dict((', '.join(x.packages), x.label) for x in flat_params['package_sets'])
 
 def canonical_os_string(os_release):
     '''Make the OS release from test parameters or /etc/redhat/release human readable'''
@@ -95,15 +73,6 @@ def canonical_os_string(os_release):
     result = result.replace('centos', 'CentOS')
     result = re.sub(r'_(\d)_.*', r' \1', result)
     return result
-
-def canonical_pkg_string(package, mapping):
-    '''Take a package set and a dictionary mapping of package sets to packages human readable strings'''
-    try:
-        return mapping[package]
-    except KeyError:
-        # Replace commonly installed java packages with an *
-        return re.sub(r'java-1.7.0-openjdk-devel,\s*osg-java7-compat,\s*osg-java7-devel-compat,\s+',
-                      '*', package)
 
 def canonical_src_string(sources):
     '''Make the repo source string human readable'''

--- a/vmu.py
+++ b/vmu.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python
 
-'''A collection of functions that are used across the various VMU automated test scripts'''
+'''A collection of functions that are used across the various VMU automated test
+scripts'''
 
 from glob import glob
 import re
 import sys
 import yaml
-import copy
 
 def die(message, code=1):
     '''Write message to STDERR and exit with code'''
@@ -115,3 +115,83 @@ def canonical_src_string(sources):
     result = re.sub(r',', ' + ', result)
     result = re.sub(r'^(\d+\.\d+)(.*-> )(?!\d)', '\\1\\2\\1 ', result) # Duplicate release series, when needed
     return result.strip()
+
+class ParamError(Exception):
+    """Exception for errors in parameter files"""
+    pass
+
+class PackageSet(object):
+    """A class for comparing package sets as specified in VMU test parameters
+
+    Instance parameters:
+
+    label: string describing the package set, used for reporting
+    packages: list of packages as strings
+    selinux: boolean to turn on/off SELinux enforcing mode (default: False)
+    java: boolean to pre-install OSG java packages (default: True)
+
+    PackageSets are equal if their 'packages' lists are the same. If 'packages'
+    lists are equal but 'label' is not, ParamError is raised.
+
+    PackageSets are sorted by labels according to LABEL_ORDER. Unknown labels
+    are sorted alphanumerically after the known labels.
+    """
+
+    OSG_JAVA_DEFAULT = True
+    SELINUX_DEFAULT = False
+    LABEL_ORDER = ['All', 'All + GRAM', 'All + GRAM (3.2)', 'HTCondor', 'GridFTP', 'BeStMan', 'VOMS', 'GUMS']
+
+    def __init__(self, label, packages, selinux=SELINUX_DEFAULT, java=OSG_JAVA_DEFAULT):
+        if not label:
+            raise ParamError("PackageSet 'label' field cannot be blank")
+        if not packages:
+            raise ParamError("PackageSet 'packages' field must be non-empty list")
+        self.label = label
+        self.selinux = selinux
+        self.java = java
+
+        if self.java:
+            self.packages = ['java-1.7.0-openjdk-devel', 'osg-java7-compat', 'osg-java7-devel-compat'] + packages
+        else:
+            self.packages = packages
+
+    def __eq__(self, other):
+        if isinstance(other, PackageSet):
+            if self.packages == other.packages:
+                if self.label != other.label:
+                    raise ParamError('Different package set tags refer to the same set of packages')
+                return True
+            return False
+        return NotImplemented
+
+    def __ne__(self, other):
+        result = self.__eq__(other)
+        if result is NotImplemented:
+            return result
+        return not result
+
+    def __lt__(self, other):
+        def get_sort_val(pkg_set):
+            try:
+                return pkg_set.LABEL_ORDER.index(pkg_set.label)
+            except ValueError:
+                return pkg_set.label
+        return get_sort_val(self) < get_sort_val(other)
+
+    def __hash__(self):
+        # Treat similarly labeled sets of packages as equal for hashing;
+        # SELinux status can differ on a per-run basis
+        return hash(repr(self).replace('%s, ' % self.selinux, ''))
+
+    def __repr__(self):
+        return str([self.label, self.selinux, self.packages])
+
+    @classmethod
+    def from_dict(cls, pkg_set_dict):
+        '''Create a PackageSet object from a dictionary, setting selinux and
+        java attributes to SELINUX_DEFAULT and OSG_JAVA_DEFAULT, respectively,
+        if they're not defined'''
+        return cls(pkg_set_dict['label'],
+                   pkg_set_dict['packages'],
+                   pkg_set_dict.get('selinux', cls.SELINUX_DEFAULT),
+                   pkg_set_dict.get('osg_java', cls.OSG_JAVA_DEFAULT))

--- a/vmu.py
+++ b/vmu.py
@@ -33,7 +33,7 @@ def load_run_params(param_dir):
             # skip non-yaml files
             pass
         else:
-            if set(param_contents.iterkeys()) == set(['platform', 'sources', 'package_sets']):
+            if set(param_contents.iterkeys()) == set(['platforms', 'sources', 'package_sets']):
                 param_contents['package_sets'] = [PackageSet.from_dict(x) for x in param_contents['package_sets']]
                 run_params.append(param_contents)
     if not run_params:
@@ -43,7 +43,7 @@ def load_run_params(param_dir):
 def flatten_run_params(params_list):
     '''Combines multiple run parameter files into a single dictionary eliminating duplicates in the 'platforms',
     'sources', and 'package_sets' sections. Sorts the 'package_sets' section, leaving the others unsorted. '''
-    result = {'platform': [], 'sources': [], 'package_sets': []}
+    result = {'platforms': [], 'sources': [], 'package_sets': []}
     for param_file_contents in params_list:
         for section in param_file_contents.iterkeys():
             section_contents = param_file_contents[section]
@@ -67,7 +67,7 @@ def canonical_os_string(os_release):
     result = result.replace('Scientific Linux', 'SL')
     result = result.replace('CentOS Linux', 'CentOS')
     result = re.sub(r'(\d)\.\d+.*', r'\1', result)
-    # Handle OS string from 'platform' test parameters
+    # Handle OS string from 'platforms' test parameters
     result = result.replace('rhel', 'RHEL')
     result = result.replace('sl', 'SL')
     result = result.replace('centos', 'CentOS')

--- a/vmu.py
+++ b/vmu.py
@@ -23,7 +23,7 @@ def load_run_params(param_dir):
     '''Read all yaml parameter files in a directory and add them to the list'''
     run_params = []
     # Slurp param files in reverse order so that the latest OSG versions show
-    # at the top of the results 
+    # at the top of the results
     for param_file in reversed(sorted(glob("%s/*" % param_dir))):
         with open(param_file, 'r') as yaml_file:
             yaml_contents = yaml_file.read()
@@ -33,12 +33,11 @@ def load_run_params(param_dir):
             # skip non-yaml files
             pass
         else:
-            if param_contents.has_key('platform') \
-               and param_contents.has_key('sources') \
-               and param_contents.has_key('packages'):
+            if set(param_contents.iterkeys()) == set(['platform', 'sources', 'package_sets']):
+                param_contents['package_sets'] = [PackageSet.from_dict(x) for x in param_contents['package_sets']]
                 run_params.append(param_contents)
     if not run_params:
-        die("Could not find parameter files in parameter directory '%s'" % param_dir)
+        raise ParamError('Could not find parameter files in parameter directory: %s' % param_dir)
     return run_params
 
 def flatten_run_params(params_list):

--- a/vmu.py
+++ b/vmu.py
@@ -134,8 +134,11 @@ class PackageSet(object):
         if isinstance(other, PackageSet):
             if self.packages == other.packages:
                 if self.label != other.label:
-                    raise ParamError('Different package set tags refer to the same set of packages')
+                    raise ParamError("Different package set tags ('%s', '%s') refer to the same set of packages. " %
+                                     (self.label, other.label) + "Check if java attributes are different.")
                 return True
+            elif self.label == other.label:
+                raise ParamError("Package set label '%s' refers to different sets of packages" % self.label)
             return False
         return NotImplemented
 

--- a/vmu.py
+++ b/vmu.py
@@ -33,7 +33,7 @@ def load_run_params(param_dir):
             # skip non-yaml files
             pass
         else:
-            if set(param_contents.keys()) == set(['platforms', 'sources', 'package_sets']):
+            if set(param_contents) == set(['platforms', 'sources', 'package_sets']):
                 param_contents['package_sets'] = [PackageSet.from_dict(x) for x in param_contents['package_sets']]
                 run_params.append(param_contents)
     if not run_params:


### PR DESCRIPTION
This PR is big so all help and eyes are appreciated (@matyasselmeci , @edquist). The bulk of the changes are due to the new parameter file format and changes made to accommodate it: 

- New `PackageSet` class 
- Changes to the VMU module
- Tests for the VMU module (requires mock)
- Updates to the DAG scripts 

This new format gives us a much better VMU to osg-test interface and finer control over sets of tests: the actual [SELinux implementation](a28a759) is small and we could just as easily add other osg-test options (maybe add osg-test's `timeout` option so devs can control VMU payload timeouts?).

And of course, results using the aforementioned changes: http://vdt.cs.wisc.edu/tests/20161215-1336/results.html