### PR TITLE
Mark runs with 0 successful tests as failures

### DIFF
--- a/analyze-test-run
+++ b/analyze-test-run
@@ -25,7 +25,16 @@ def indent_block(block, indent=4):
     return output
 
 def process_run(run):
-    status = 0
+    # mapping osg-test status to column in the report
+    test_status = {'pass': 0,
+                   'died': 1,
+                   'fail': 2,
+                   'update': 2,
+                   'install': 2,
+                   'cleanup': 3,
+                   'ignore': 4,
+                   'timeout': 5}
+
     if run['run_status'] != 0:
         if ('osg_test_logfile' not in run) or (run['osg_test_logfile'] is None):
             logfile_text = 'osg-test did not run'
@@ -42,17 +51,11 @@ def process_run(run):
             deaths_by_host[host].append(report)
         else:
             deaths_by_host[host] = [report]
-        status = 1
-    elif (run['tests_bad_skip'] + run['tests_failed'] + run['tests_error']) > 0:
-        if run['osg_test_status'] == 'ignore':
-            status = 4
-        elif re.match('special_cleanup', run['tests_messages'][0]):
-            status = 3
-        else:
-            status = 2
-    elif run['osg_test_status'] == 'timeout':
-        status = 5
-    return status
+        return test_status['died']
+    else:
+        # ' yum_timeout' can be appended to install, update, or timeout failures; ignore it
+        simple_test_status = run['osg_test_status'].split()[0]
+        return test_status[simple_test_status]
 
 def tally_run_results(container, key, status):
     if key not in container:

--- a/analyze_job_output.py
+++ b/analyze_job_output.py
@@ -301,5 +301,8 @@ if __name__ == '__main__':
             else: raise ValueError()
     data['tests_ok'] = data['tests_total'] - \
       (data['tests_failed'] + data['tests_error'] + data['tests_bad_skip'] + data['tests_ok_skip'])
-    
+
+    if data['tests_ok'] == 0 and data['osg_test_status'] != 'timeout':
+        data['osg_test_status'] = 'fail'
+
     write_yaml(data)


### PR DESCRIPTION
If you're running VMU tests against a broken version of osg-test where it fails immediately, the VMU reports will say that all tests ran ok because there were no test failures (http://vdt.cs.wisc.edu/tests/20161220-1324/results.html). This change marks runs with 0 successful tests as failures. Here are two test runs, one against a broken osg-test and the other against a fixed osg-test:

* Broken: http://vdt.cs.wisc.edu/tests/20170104-1209/results.html
* Fixed: http://vdt.cs.wisc.edu/tests/20161221-1025/results.html