### PR TITLE
introduce '-p' option to base parameters on a previous run

### DIFF
--- a/osg-run-tests
+++ b/osg-run-tests
@@ -34,7 +34,7 @@ while getopts :nh opt; do
             exit 0
             ;;
         \?)
-            echo "Invalid option: -$OPTARG"
+            echo "Invalid option: -$opt"
             print_help
             exit 1
             ;;

--- a/osg-run-tests
+++ b/osg-run-tests
@@ -12,19 +12,42 @@ safe_run()
 
 print_help()
 {
-    echo "help: $0 [-n] <label>"
+    echo "help: $0 [-n] [-p YYYYMMDD-HHMM] <label>"
     echo "Options:"
     echo "    -n"
     echo "       Run as nightly test i.e. immediately submit the DAG after setting up the test run"
+    echo "    -p YYYYMMDD-HHMM"
+    echo "       Use yaml parameters from a previous run with given timestamp"
     echo '    -h, -help, --help'
     echo "       Print this dialogue"
 
 }
 
+TEST_HOME=/osgtest/runs
 NIGHTLY=0
+PARAMETERS_BASE=""
+
+set_parameters_base()
+{
+    case $1 in
+        20[0-9][0-9][0-1][0-9][0-3][0-9]-[0-2][0-9][0-5][0-9])
+            PARAMETERS_BASE=$TEST_HOME/run-$1/parameters.d
+            if ! [ -d "$PARAMETERS_BASE" ]; then
+                echo "No such directory: '$PARAMETERS_BASE'"
+                print_help
+                exit 1
+            fi
+            ;;
+        *)
+            echo "Option '-p' takes a YYYYMMDD-HHMM argument."
+            print_help
+            exit 1
+            ;;
+    esac
+}
 
 # Parse options and required label arg
-while getopts :nh opt; do
+while getopts :nhp: opt; do
     case $opt in
         n)
             NIGHTLY=1
@@ -32,6 +55,9 @@ while getopts :nh opt; do
         h)
             print_help
             exit 0
+            ;;
+        p)
+            set_parameters_base "$OPTARG"
             ;;
         \?)
             echo "Invalid option: -$opt"
@@ -50,7 +76,6 @@ if [[ $# -ne 1 ]]; then
 fi
 
 LABEL="$1"
-TEST_HOME=/osgtest/runs
 if [[ ! -d $TEST_HOME ]]; then
     safe_run mkdir -p $TEST_HOME
 fi
@@ -80,6 +105,13 @@ safe_run cp -r \
     vmu-reporter html-report.sub taglib.py \
     upload-job-output upload-job-output.sub \
     $RUN_DIRECTORY/
+
+if [ -n "$PARAMETERS_BASE" ]; then
+    echo "Copying run parameters from $PARAMETERS_BASE"
+    rm -f $RUN_DIRECTORY/parameters.d/*.yaml
+    safe_run cp "$PARAMETERS_BASE"/*.yaml $RUN_DIRECTORY/parameters.d/
+fi
+
 cp /osgtest/rpms/osg-test-*.rpm $RUN_DIRECTORY/ 2> /dev/null
 cd $RUN_DIRECTORY
 if [ "x$TEMP_DIR" != 'x' ]; then


### PR DESCRIPTION
It comes up occasionally that I want to do a VMU run with identical parameters.d configuration as some previous run, perhaps after a new build hits minefield, and rather than having to make the same manual edits to the yaml files or even manually copy them from the parameters.d dir from the previous run, it would be convenient to just let `osg-run-tests` set this up if requested on the command line.

I've tried it out with the changes and it works for me.