### PR TITLE
Remove GRAM packages already installed by osg-tested-internal

### DIFF
--- a/parameters.d/osg32-updates.yaml
+++ b/parameters.d/osg32-updates.yaml
@@ -33,21 +33,6 @@ package_sets:
     osg_java: True
     packages:
       - osg-tested-internal
-  # Explicitly add GRAM packages since they were dropped from osg-ce (SOFTWARE-2278, SOFTWARE-2291)
-  - label: All + GRAM (3.2)
-    selinux: False
-    osg_java: True
-    packages:
-      - osg-tested-internal
-      - globus-gatekeeper
-      - globus-gram-client-tools
-      - globus-gram-job-manager
-      - globus-gram-job-manager-fork
-      - globus-gram-job-manager-fork-setup-poll
-      - gratia-probe-gram
-      - globus-gram-job-manager-scripts
-      - globus-gram-job-manager-condor
-      - globus-gram-job-manager-pbs-setup-seg
   - label: HTCondor
     selinux: False
     osg_java: True


### PR DESCRIPTION
I noticed this redundancy when looking at package installations across runs.

We dropped GRAM packages from osg-ce in SOFTWARE-2278/SOFTWARE-2291 so
we added an extra list of packages. However, they remained as
osg-tested-internal Requires

