### PR TITLE
Enable SELinux for all tests that we expect to pass

### DIFF
--- a/parameters.d/osg32-updates.yaml
+++ b/parameters.d/osg32-updates.yaml
@@ -29,12 +29,12 @@ package_sets:
   # osg_java - Pre-install OSG java packages (default: True)
   ##################
   - label: All
-    selinux: False
+    selinux: True
     osg_java: True
     packages:
       - osg-tested-internal
   - label: HTCondor
-    selinux: False
+    selinux: True
     osg_java: True
     packages:
       - condor.x86_64
@@ -48,19 +48,19 @@ package_sets:
       - edg-mkgridmap
       - rsv
   - label: BeStMan
-    selinux: False
+    selinux: True
     osg_java: True
     packages:
       - osg-se-bestman
       - rsv
   - label: VOMS
-    selinux: False
+    selinux: True
     osg_java: True
     packages:
       - osg-voms
       - rsv
   - label: GUMS
-    selinux: False
+    selinux: True
     osg_java: True
     packages:
       - osg-gums

--- a/parameters.d/osg33-el7-testing.yaml
+++ b/parameters.d/osg33-el7-testing.yaml
@@ -1,13 +1,13 @@
 ###################
-# OSG 3.3 EL6 tests
+# OSG 3.3 EL7 tests
 # File format documention:
 # https://twiki.opensciencegrid.org/bin/view/SoftwareTeam/TestRunsAsVMs
 ###################
 
 platforms:
-  - centos_6_x86_64
-  - rhel_6_x86_64
-  - sl_6_x86_64
+  - centos_7_x86_64
+  - rhel_7_x86_64
+  - sl_7_x86_64
 
 sources:
   ###################
@@ -17,10 +17,8 @@ sources:
   # Run osg-test with packages from 3.2-release and 3.2-testing that are then upgraded to 3.3-testing and 3-3-upcoming-testing:
   # 3.2; osg, osg-testing > 3.3/osg-testing, osg-upcoming-testing
   ###################
-  - opensciencegrid:master; 3.3; osg
   - opensciencegrid:master; 3.3; osg-testing
   - opensciencegrid:master; 3.3; osg > osg-testing
-  - opensciencegrid:master; 3.3; osg, osg-upcoming
   - opensciencegrid:master; 3.3; osg-testing, osg-upcoming-testing
   - opensciencegrid:master; 3.3; osg > osg-testing, osg-upcoming-testing
 

--- a/parameters.d/osg33-el7.yaml
+++ b/parameters.d/osg33-el7.yaml
@@ -18,11 +18,7 @@ sources:
   # 3.2; osg, osg-testing > 3.3/osg-testing, osg-upcoming-testing
   ###################
   - opensciencegrid:master; 3.3; osg
-  - opensciencegrid:master; 3.3; osg-testing
-  - opensciencegrid:master; 3.3; osg > osg-testing
   - opensciencegrid:master; 3.3; osg, osg-upcoming
-  - opensciencegrid:master; 3.3; osg-testing, osg-upcoming-testing
-  - opensciencegrid:master; 3.3; osg > osg-testing, osg-upcoming-testing
 
 package_sets:
   #### Required ####
@@ -58,19 +54,19 @@ package_sets:
       - edg-mkgridmap
       - rsv
   - label: BeStMan
-    selinux: False
+    selinux: True
     osg_java: True
     packages:
       - osg-se-bestman
       - rsv
   - label: VOMS
-    selinux: False
+    selinux: True
     osg_java: True
     packages:
       - osg-voms
       - rsv
   - label: GUMS
-    selinux: False
+    selinux: True
     osg_java: True
     packages:
       - osg-gums

--- a/vmu-reporter
+++ b/vmu-reporter
@@ -196,7 +196,7 @@ def generate_cell(run):
         test_log_filename = os.path.basename(test_log_path)
         link_location = '%s/%s' % (run_url_output_dir, test_log_filename)
         link_text = "%s %s %s%s" % (run['tests_ok'], run['tests_ok_skip'], fail_count,
-                                    ' &#128274;' if run['selinux'] else '')
+                                    ' &#128275;' if not run['selinux'] else '')
 
         try:
             status_regex = r'(install|update|timeout)\s*(yum_timeout)?'


### PR DESCRIPTION
Since the `condor` versions in release are the only packages holding us back, we can enable SELinux eveywhere except EL7 release tests once `condor-8.6.0` makes it into testing.