### PR TITLE
Increase request_disk to reflect greater actual usage

### DIFF
--- a/single-test-run.sub
+++ b/single-test-run.sub
@@ -12,7 +12,7 @@ periodic_hold           = (time() - JobCurrentStartDate > 28800)
 periodic_release        = ( (HoldReasonCode == 3) && (NumJobStarts < 2) ) || ( (HoldReasonCode == 6) && regexp("VMGAHP_ERR_INTERNAL", HoldReason) )
 periodic_remove         = ( (JobStatus == 5) && (HoldReasonCode =?= 3) && (NumJobStarts >= 2) )
 
-request_disk            = 6GB
+request_disk            = 8GB
 requirements            = ((HasGluster == True) && (HasVirshDefaultNetwork =?= True))
 
 log                     = osg-test-cat.log


### PR DESCRIPTION
Looking at VM job logs, we've been going slightly over our requested disk usage. Bumped it up to 8GB, which should be good for a while.

Test results: http://vdt.cs.wisc.edu/tests/20170528-1138/packages.html