### PR TITLE
Revert "Disable RHEL7 tests until we figure out why they're hanging"

### DIFF
--- a/parameters.d/osg33.yaml
+++ b/parameters.d/osg33.yaml
@@ -9,6 +9,7 @@ platforms:
   - rhel_6_x86_64
   - sl_6_x86_64
   - centos_7_x86_64
+  - rhel_7_x86_64
   - sl_7_x86_64
 
 sources:


### PR DESCRIPTION
This reverts commit 1e8abdd8. Disabling the rolling RHEL7 repo in the base VM images fixed the hanging issues we were seeing.

Test results here: http://vdt.cs.wisc.edu/tests/20170530-1427/results.html
and here: http://vdt.cs.wisc.edu/tests/20170531-1128/results.html