### PR TITLE
yum update to the latest OS/EPEL packages before running osg-test

### DIFF
--- a/run-job
+++ b/run-job
@@ -106,6 +106,10 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+# make sure we have the latest OS/EPEL packages so osg-test doesn't update
+# _those_
+run_command_with_retries 8 yum -y update
+
 run_command_with_retries 8 yum -y install $priorities_rpm
 log_command sed -i -e 's/^plugins=.*$/plugins=1/' /etc/yum.conf
 rpm -q osg-release || run_command_with_retries 8 rpm --upgrade $osg_url


### PR DESCRIPTION
This will keep osg-test from updating the OS during update tests.