### PR TITLE
Temporarily disable RHEL6 tests until chtc-inf fixes the base image

### DIFF
--- a/parameters.d/osg33.yaml
+++ b/parameters.d/osg33.yaml
@@ -6,7 +6,6 @@
 
 platforms:
   - centos_6_x86_64
-  - rhel_6_x86_64
   - sl_6_x86_64
   - centos_7_x86_64
   - rhel_7_x86_64

--- a/parameters.d/osg34.yaml
+++ b/parameters.d/osg34.yaml
@@ -6,7 +6,6 @@
 
 platforms:
   - centos_6_x86_64
-  - rhel_6_x86_64
   - sl_6_x86_64
   - centos_7_x86_64
   - rhel_7_x86_64


### PR DESCRIPTION
They're causing runs to take the maximum amount of time to complete