### PR TITLE
include xrootd{,-lcmaps} in hdfs plugins package list

### DIFF
--- a/parameters.d/osg33.yaml
+++ b/parameters.d/osg33.yaml
@@ -53,8 +53,10 @@ package_sets:
       - gfal2-plugin-gridftp
       - gfal2-util
       - gfal2-plugin-file
+      - xrootd
       - xrootd-hdfs
       - xrootd-client
+      - xrootd-lcmaps
       - globus-proxy-utils # proxy required for all transfer tests
   - label: BeStMan (java)
     packages:


### PR DESCRIPTION
Without these, I see the following explanatory messages in the `OK SKIPS` section:

```
test_01_config_auth (osgtest.tests.test_15_xrootd.TestStartXrootd) missing xrootd xrootd-lcmaps
test_02_configure_xrootd (osgtest.tests.test_15_xrootd.TestStartXrootd) missing xrootd
test_04_start_xrootd (osgtest.tests.test_15_xrootd.TestStartXrootd) missing xrootd
```