### PR TITLE
Drop RHEL tests again

### DIFF
--- a/parameters.d/osg33.yaml
+++ b/parameters.d/osg33.yaml
@@ -6,10 +6,8 @@
 
 platforms:
   - centos_6_x86_64
-  - rhel_6_x86_64
   - sl_6_x86_64
   - centos_7_x86_64
-  - rhel_7_x86_64
   - sl_7_x86_64
 
 sources:

--- a/parameters.d/osg34.yaml
+++ b/parameters.d/osg34.yaml
@@ -6,10 +6,8 @@
 
 platforms:
   - centos_6_x86_64
-  - rhel_6_x86_64
   - sl_6_x86_64
   - centos_7_x86_64
-  - rhel_7_x86_64
   - sl_7_x86_64
 
 sources:


### PR DESCRIPTION
They're holding up all the tests and likely won't be close to being
fixed until the base VM image generation is fixed