### PR TITLE
give HDFS Plugins sets unique names

### DIFF
--- a/parameters.d/osg33.yaml
+++ b/parameters.d/osg33.yaml
@@ -44,7 +44,7 @@ package_sets:
     packages:
       - osg-gridftp
       - rsv
-  - label: HDFS Plugins
+  - label: HDFS Plugins (java)
     packages:
       - osg-gridftp-hdfs
       - globus-gass-copy-progs


### PR DESCRIPTION
Failing now due to #54...

For some reason, the 3.3 `HDFS Plugins` section did not have a `(java)` suffix (the other 3.3 package sets do).  This breaks when `osg34-hadoop.yaml` is added with the same label but no osg_java.