### PR TITLE
Drop EL7 GUMS tests

### DIFF
--- a/osg33-gums.yaml
+++ b/osg33-gums.yaml
@@ -7,8 +7,6 @@
 platforms:
   - centos_6_x86_64
   - sl_6_x86_64
-  - centos_7_x86_64
-  - sl_7_x86_64
 
 sources:
   ###################
@@ -31,44 +29,8 @@ package_sets:
   # osg_java - Pre-install OSG java packages (default: True)
   # rng - Install entropy generation package (default: False)
   ##################
-  - label: All (java)
+  - label: GUMS
     rng: True
     packages:
-      - osg-tested-internal
-  - label: HTCondor (java)
-    packages:
-      - condor.x86_64
-      - osg-ce-condor
+      - osg-gums
       - rsv
-  - label: GridFTP (java)
-    packages:
-      - osg-gridftp
-      - rsv
-  - label: HDFS Plugins (java)
-    packages:
-      - osg-gridftp-hdfs
-      - globus-gass-copy-progs
-      - gfal2-plugin-gridftp
-      - gfal2-util
-      - gfal2-plugin-file
-      - xrootd
-      - xrootd-hdfs
-      - xrootd-client
-      - xrootd-lcmaps
-      - lcmaps-db-templates
-      - vo-client-lcmaps-voms
-      - globus-proxy-utils # proxy required for all transfer tests
-  - label: BeStMan (java)
-    packages:
-      - osg-se-bestman
-      - rsv
-  - label: VOMS (java)
-    rng: True
-    packages:
-      - osg-voms
-      - rsv
-  # - label: CVMFS
-  #   osg_java: False
-  #   package:
-  #     - osg-oasis
-  #     - singularity-runtime


### PR DESCRIPTION
We build GUMS against bouncycastle-1.50, which is no longer being
shipped in EPEL. We couldn't easily get GUMS to build against the new
version of bouncycastle that EPEL ships (1.58) and seeing how GUMS
retirement is
impending (https://opensciencegrid.github.io/technology/policy/gums-retire/),
we decided not to fix it.

Successful (except for the failures related to 3.3 release test) nightly run: http://vdt.cs.wisc.edu/tests/20180419-1007/results.html