### PR TITLE
add -P option for prerelease test parameters

### DIFF
--- a/osg-run-tests
+++ b/osg-run-tests
@@ -12,10 +12,12 @@ safe_run()
 
 print_help()
 {
-    echo "help: $0 [-n] [-p YYYYMMDD-HHMM] <label>"
+    echo "help: $0 [-n] [-P|-p YYYYMMDD-HHMM] <label>"
     echo "Options:"
     echo "    -n"
     echo "       Run as nightly test i.e. immediately submit the DAG after setting up the test run"
+    echo "    -P"
+    echo "       Use yaml parameters for testing the prerelease repos"
     echo "    -p YYYYMMDD-HHMM"
     echo "       Use yaml parameters from a previous run with given timestamp"
     echo '    -h, -help, --help'
@@ -25,6 +27,7 @@ print_help()
 
 TEST_HOME=/osgtest/runs
 NIGHTLY=0
+PRERELEASE=0
 PARAMETERS_BASE=""
 
 set_parameters_base()
@@ -47,7 +50,7 @@ set_parameters_base()
 }
 
 # Parse options and required label arg
-while getopts :nhp: opt; do
+while getopts :nhPp: opt; do
     case $opt in
         n)
             NIGHTLY=1
@@ -55,6 +58,8 @@ while getopts :nhp: opt; do
         h)
             print_help
             exit 0
+            ;;
+        P)  PRERELEASE=1
             ;;
         p)
             set_parameters_base "$OPTARG"
@@ -96,7 +101,7 @@ safe_run git clone --quiet --depth 1 https://github.com/opensciencegrid/vm-test-
 cd $GIT_CHECKOUT_DIR
 safe_run cp -r \
     master-run.dag \
-    generate-dag.sub generate-dag osg-test.conf parameters.d test-exceptions.yaml component-tags.yaml \
+    generate-dag.sub generate-dag osg-test.conf test-exceptions.yaml component-tags.yaml \
     create-io-images.sub create-io-images \
     run-job osg-test.patch test-changes.patch osg-release.patch single-test-run.sub true.sub inner-dag.config \
     process-job-output extract-job-output analyze_job_output.py \
@@ -105,6 +110,13 @@ safe_run cp -r \
     vmu-reporter html-report.sub taglib.py \
     upload-job-output upload-job-output.sub \
     $RUN_DIRECTORY/
+
+if [ $PRERELEASE -eq 1 ]; then
+    echo "Using parameters for prerelease tests"
+    safe_run cp -r parameters.d-prerelease $RUN_DIRECTORY/parameters.d
+else
+    safe_run cp -r parameters.d $RUN_DIRECTORY/
+fi
 
 if [ -n "$PARAMETERS_BASE" ]; then
     echo "Copying run parameters from $PARAMETERS_BASE"

--- a/parameters.d-prerelease/osg33.yaml
+++ b/parameters.d-prerelease/osg33.yaml
@@ -1,0 +1,17 @@
+platforms:
+  - centos_6_x86_64
+  - sl_6_x86_64
+  - centos_7_x86_64
+  - sl_7_x86_64
+
+sources:
+  - opensciencegrid:master; 3.3; osg-prerelease
+  - opensciencegrid:master; 3.3; osg > osg-prerelease
+
+package_sets:
+  - label: All (java)
+    selinux: True
+    osg_java: True
+    rng: True
+    packages:
+      - osg-tested-internal

--- a/parameters.d-prerelease/osg34-hadoop.yaml
+++ b/parameters.d-prerelease/osg34-hadoop.yaml
@@ -1,0 +1,23 @@
+platforms:
+  - centos_7_x86_64
+  - sl_7_x86_64
+
+sources:
+  - opensciencegrid:master; 3.4; osg-prerelease, osg-upcoming, osg-upcoming-prerelease
+
+package_sets:
+  - label: HDFS Plugins
+    osg_java: False
+    packages:
+      - osg-gridftp-hdfs
+      - globus-gass-copy-progs
+      - gfal2-plugin-gridftp
+      - gfal2-util
+      - gfal2-plugin-file
+      - xrootd
+      - xrootd-hdfs
+      - xrootd-client
+      - xrootd-lcmaps
+      - lcmaps-db-templates
+      - vo-client-lcmaps-voms
+      - globus-proxy-utils # proxy required for all transfer tests

--- a/parameters.d-prerelease/osg34.yaml
+++ b/parameters.d-prerelease/osg34.yaml
@@ -1,0 +1,19 @@
+platforms:
+  - centos_6_x86_64
+  - sl_6_x86_64
+  - centos_7_x86_64
+  - sl_7_x86_64
+
+sources:
+  - opensciencegrid:master; 3.4; osg-prerelease
+  - opensciencegrid:master; 3.4; osg > osg-prerelease
+  - opensciencegrid:master; 3.3; osg > 3.4/osg-prerelease
+  - opensciencegrid:master; 3.4; osg-prerelease, osg-upcoming-prerelease, osg-upcoming
+  - opensciencegrid:master; 3.4; osg > osg-prerelease, osg-upcoming-prerelease, osg-upcoming
+
+package_sets:
+  - label: All
+    selinux: True
+    osg_java: False
+    packages:
+      - osg-tested-internal


### PR DESCRIPTION
discussed this with TimT - maintaining a default set of parameters
for testing the prerelease repos is better than maintaining those
parameters embedded in a doc and then copy/pasting them in every time.