### PR TITLE
fix typo in CVMFS+Singularity package set (SOFTWARE-3343)

### DIFF
--- a/parameters.d/osg34.yaml
+++ b/parameters.d/osg34.yaml
@@ -52,6 +52,6 @@ package_sets:
       - rsv
   # - label: CVMFS + Singularity
   #   osg_java: False
-  #   package:
+  #   packages:
   #     - osg-oasis
   #     - singularity-runtime


### PR DESCRIPTION
some jerk left out the 's' in packages