### PR TITLE
Tighten VMU runtimes

### DIFF
--- a/single-test-run.sub
+++ b/single-test-run.sub
@@ -9,8 +9,10 @@ vm_no_output_vm         = false
 vm_vnc                  = true
 # Most VM jobs complete in less than 2 hours, give them a 2 hour buffer
 periodic_hold           = (time() - JobCurrentStartDate > 14400)
-periodic_release        = ( (HoldReasonCode == 3) && (NumJobStarts < 2) ) || ( (HoldReasonCode == 6) && regexp("VMGAHP_ERR_INTERNAL", HoldReason) )
-periodic_remove         = ( (JobStatus == 5) && (HoldReasonCode =?= 3) && (NumJobStarts >= 2) )
+periodic_release        = ( (HoldReasonCode == 3) && (NumJobStarts < 3) ) || ( (HoldReasonCode == 6) && regexp("VMGAHP_ERR_INTERNAL", HoldReason) )
+# Most VM jobs spend less than 12 hours in the queue
+# We can remove jobs since the DAG can handle removed nodes
+periodic_remove         = ( (JobStatus == 5) && (HoldReasonCode =?= 3) && (NumJobStarts >= 3) ) || (time() - QDate >  43200)
 
 request_disk            = 8GB
 requirements            = ((HasGluster == True) && (HasVirshDefaultNetwork =?= True))

--- a/single-test-run.sub
+++ b/single-test-run.sub
@@ -7,8 +7,8 @@ vm_memory               = 2048
 vm_networking           = true
 vm_no_output_vm         = false
 vm_vnc                  = true
-# osg-test timeout is 4h, give it a 4h buffer
-periodic_hold           = (time() - JobCurrentStartDate > 28800)
+# Most VM jobs complete in less than 2 hours, give them a 2 hour buffer
+periodic_hold           = (time() - JobCurrentStartDate > 14400)
 periodic_release        = ( (HoldReasonCode == 3) && (NumJobStarts < 2) ) || ( (HoldReasonCode == 6) && regexp("VMGAHP_ERR_INTERNAL", HoldReason) )
 periodic_remove         = ( (JobStatus == 5) && (HoldReasonCode =?= 3) && (NumJobStarts >= 2) )
 


### PR DESCRIPTION
About 94% of nightly VMU jobs run for < 2 hours