### PR TITLE
Add rolling release repos to tests (SOFTWARE-3465)

### DIFF
--- a/parameters.d/osg34-el7-only.yaml
+++ b/parameters.d/osg34-el7-only.yaml
@@ -18,6 +18,7 @@ sources:
   # 3.2; osg, osg-testing > 3.3/osg-testing, osg-upcoming-testing
   ###################
   - opensciencegrid:master; 3.4; osg
+  - opensciencegrid:master; 3.4; osg-rolling
   - opensciencegrid:master; 3.4; osg-testing
   - opensciencegrid:master; 3.4; osg > osg-testing
 

--- a/parameters.d/osg34-singularity.yaml
+++ b/parameters.d/osg34-singularity.yaml
@@ -20,6 +20,7 @@ sources:
   # 3.2; osg, osg-testing > 3.3/osg-testing, osg-upcoming-testing
   ###################
   - opensciencegrid:master; 3.4; osg
+  - opensciencegrid:master; 3.4; osg-rolling
   - opensciencegrid:master; 3.3; osg > 3.4/osg
 
 package_sets:

--- a/parameters.d/osg34.yaml
+++ b/parameters.d/osg34.yaml
@@ -20,10 +20,12 @@ sources:
   # 3.2; osg, osg-testing > 3.3/osg-testing, osg-upcoming-testing
   ###################
   - opensciencegrid:master; 3.4; osg
+  - opensciencegrid:master; 3.4; osg-rolling
   - opensciencegrid:master; 3.4; osg-testing
   - opensciencegrid:master; 3.4; osg > osg-testing
   - opensciencegrid:master; 3.3; osg > 3.4/osg
   - opensciencegrid:master; 3.4; osg, osg-upcoming
+  - opensciencegrid:master; 3.4; osg-rolling, osg-upcoming-rolling
   - opensciencegrid:master; 3.4; osg-testing, osg-upcoming-testing
   - opensciencegrid:master; 3.4; osg > osg-testing, osg-upcoming-testing
 

--- a/parameters.d/osgup-singularity.yaml
+++ b/parameters.d/osgup-singularity.yaml
@@ -20,6 +20,7 @@ sources:
   # 3.2; osg, osg-testing > 3.3/osg-testing, osg-upcoming-testing
   ###################
   - opensciencegrid:master; 3.4; osg, osg-upcoming
+  - opensciencegrid:master; 3.4; osg-rolling, osg-upcoming-rolling
   - opensciencegrid:master; 3.4; osg-testing, osg-upcoming-testing
   - opensciencegrid:master; 3.4; osg > osg-testing, osg-upcoming-testing
 

--- a/vmu.py
+++ b/vmu.py
@@ -85,7 +85,9 @@ def canonical_src_string(sources):
     result = re.sub(r'osg-development', 'Development', result)
     result = re.sub(r'osg-testing', 'Testing', result)
     result = re.sub(r'osg-prerelease', 'Prerelease', result)
+    result = re.sub(r'osg-rolling', 'Rolling', result)
     result = re.sub(r'osg-upcoming-testing', 'Upcoming Testing', result)
+    result = re.sub(r'osg-upcoming-rolling', 'Upcoming Rolling', result)
     result = re.sub(r'osg-upcoming', 'Upcoming', result)
     result = re.sub(r'osg', 'Release', result) # Must come after other repos
     result = re.sub(r';', '', result)


### PR DESCRIPTION
Results: http://vdt.cs.wisc.edu/tests/20190221-1233/packages.html

We should wait to merge until the osg-release RPM has been released; I tested it by modifying run-job to take osg-release from minefield.