### PR TITLE
Add osg-gridftp-xrootd to test gridftp-dsi-posix

### DIFF
--- a/parameters.d/osg34-el7-only.yaml
+++ b/parameters.d/osg34-el7-only.yaml
@@ -64,3 +64,4 @@ package_sets:
       - lcmaps-db-templates
       - vo-client-lcmaps-voms
       - globus-proxy-utils
+      - osg-gridftp-xrootd

--- a/parameters.d/osg34.yaml
+++ b/parameters.d/osg34.yaml
@@ -52,4 +52,5 @@ package_sets:
     osg_java: False
     packages:
       - osg-gridftp
+      - osg-gridftp-xrootd
       - rsv


### PR DESCRIPTION
Tests failing with the broken XRootD here: http://vdt.cs.wisc.edu/tests/20190325-1317/packages.html
Waiting on test results with the new build of XRootD