### PR TITLE
Begin testing OSG 3.5 out of testing (SOFTWARE-3781)

### DIFF
--- a/parameters.d-prerelease/osg34.yaml
+++ b/parameters.d-prerelease/osg34.yaml
@@ -7,8 +7,6 @@ platforms:
 sources:
   - opensciencegrid:master; 3.4; osg-prerelease
   - opensciencegrid:master; 3.4; osg > osg-prerelease
-  - opensciencegrid:master; 3.4; osg-prerelease, osg-upcoming-prerelease, osg-upcoming
-  - opensciencegrid:master; 3.4; osg > osg-prerelease, osg-upcoming-prerelease, osg-upcoming
 
 package_sets:
   - label: All

--- a/parameters.d-prerelease/osg35.yaml
+++ b/parameters.d-prerelease/osg35.yaml
@@ -13,3 +13,42 @@ package_sets:
   - label: All
     packages:
       - osg-tested-internal
+  - label: GridFTP
+    packages:
+      - osg-gridftp
+      - osg-gridftp-xrootd
+  - label: CVMFS + Singularity
+    packages:
+      - osg-oasis
+      - singularity
+  - label: HDFS Plugins
+    packages:
+      - osg-gridftp-hdfs
+      - globus-gass-copy-progs
+      - gfal2-plugin-gridftp
+      - gfal2-util
+      - gfal2-plugin-file
+      - xrootd
+      - xrootd-hdfs
+      - xrootd-client
+      - xrootd-lcmaps
+      - lcmaps-db-templates
+      - vo-client-lcmaps-voms
+      - globus-proxy-utils # proxy required for all transfer tests
+  - label: XRootD Plugins
+    packages:
+      - xrootd
+      - xrootd-multiuser
+      - xrootd-lcmaps
+      - xrootd-client
+      - xrootd-fuse
+      - xrootd-scitokens
+      - lcmaps-db-templates
+      - vo-client-lcmaps-voms
+      - globus-proxy-utils
+      - osg-gridftp-xrootd
+  - label: StashCache
+    packages:
+      - stashcache-client
+      - stash-cache
+      - stash-origin

--- a/parameters.d/osg34.yaml
+++ b/parameters.d/osg34.yaml
@@ -23,10 +23,6 @@ sources:
   - opensciencegrid:master; 3.4; osg-rolling
   - opensciencegrid:master; 3.4; osg-testing
   - opensciencegrid:master; 3.4; osg > osg-testing
-  - opensciencegrid:master; 3.4; osg, osg-upcoming
-  - opensciencegrid:master; 3.4; osg-rolling, osg-upcoming-rolling
-  - opensciencegrid:master; 3.4; osg-testing, osg-upcoming-testing
-  - opensciencegrid:master; 3.4; osg > osg-testing, osg-upcoming-testing
 
 package_sets:
   #### Required ####

--- a/parameters.d/osg35-development.yaml
+++ b/parameters.d/osg35-development.yaml
@@ -17,8 +17,8 @@ sources:
   # 3.3-testing and 3-3-upcoming-testing:
   # 3.2; osg, osg-testing > 3.3/osg-testing, osg-upcoming-testing
   ###################
-  - opensciencegrid:master; 3.5; osg-testing
-  - opensciencegrid:master; 3.4; osg > 3.5/osg-testing
+  - opensciencegrid:master; 3.5; osg-development
+  - opensciencegrid:master; 3.4; osg > 3.5/osg-development
 
 package_sets:
   #### Required ####
@@ -29,6 +29,14 @@ package_sets:
   # osg_java - Pre-install OSG java packages (default: False)
   # rng - Install entropy generation package (default: False)
   ##################
+  - label: All
+    packages:
+      - osg-tested-internal
+  - label: HTCondor (3.5)
+    packages:
+      - condor.x86_64
+      - osg-ce-condor
+      - globus-proxy-utils
   - label: GridFTP (3.5)
     packages:
       - osg-gridftp


### PR DESCRIPTION
I've tagged most of the expected packages for the release into 3.5 testing so we should start seeing meaningful test results. Notable missing packages since they're not yet RFT:

- condor 8.8
- osg-configure 3.0.0
- xcache 1.1