### PR TITLE
Re-enable all/htcondor tests in 3.5 with the release of HTCondor-CE

### DIFF
--- a/parameters.d-prerelease/osg35.yaml
+++ b/parameters.d-prerelease/osg35.yaml
@@ -10,6 +10,9 @@ sources:
   - opensciencegrid:master; 3.5; osg > osg-prerelease, osg-upcoming-prerelease, osg-upcoming
 
 package_sets:
+  - label: All
+    packages:
+      - osg-tested-internal
   - label: GridFTP
     packages:
       - osg-gridftp

--- a/parameters.d/osg35.yaml
+++ b/parameters.d/osg35.yaml
@@ -35,6 +35,14 @@ package_sets:
   # osg_java - Pre-install OSG java packages (default: False)
   # rng - Install entropy generation package (default: False)
   ##################
+  - label: All
+    packages:
+      - osg-tested-internal
+  - label: HTCondor (3.5)
+    packages:
+      - condor.x86_64
+      - osg-ce-condor
+      - globus-proxy-utils
   - label: GridFTP (3.5)
     packages:
       - osg-gridftp

--- a/parameters.d/osg35.yaml
+++ b/parameters.d/osg35.yaml
@@ -40,7 +40,7 @@ package_sets:
       - osg-tested-internal
   - label: HTCondor (3.5)
     packages:
-      - condor.x86_64
+      - condor
       - osg-ce-condor
       - globus-proxy-utils
   - label: GridFTP (3.5)


### PR DESCRIPTION
To be merged in upon release of HTCondor-CE in OSG 3.5