### PR TITLE
Test 3.4 testing -> 3.5 testing

### DIFF
--- a/parameters.d/osg35.yaml
+++ b/parameters.d/osg35.yaml
@@ -22,7 +22,7 @@ sources:
   - opensciencegrid:master; 3.5; osg-testing
   - opensciencegrid:master; 3.5; osg > osg-testing
   - opensciencegrid:master; 3.4; osg > 3.5/osg
-  - opensciencegrid:master; 3.4; osg > 3.5/osg-testing
+  - opensciencegrid:master; 3.4; osg-testing > 3.5/osg-testing
   - opensciencegrid:master; 3.5; osg, osg-upcoming
   - opensciencegrid:master; 3.5; osg-rolling, osg-upcoming-rolling
   - opensciencegrid:master; 3.5; osg-testing, osg-upcoming-testing


### PR DESCRIPTION
To catch update issues with packages targeted for release. 3.4 release -> 3.5 testing won't catch issues with 3.4 packages.