### PR TITLE
Avoid qcow2 version compat issues; use HTCondor file transfer for the base images

### DIFF
--- a/bin/create-io-images
+++ b/bin/create-io-images
@@ -73,7 +73,7 @@ def create_image(config_filename):
     f.close()
 
     serial_number = re.search(r'(\d+)', config_filename).group(1)
-    image_filename = 'input-image-%s.qcow2' % (serial_number)
+    image_filename = 'input-image-%s.dsk' % (serial_number)
 
     if contents_to_filename.has_key(config_contents):
         print 'Linking from "%s" -> "%s"' % (contents_to_filename[config_contents], image_filename)
@@ -109,7 +109,7 @@ def create_image(config_filename):
         os.mkdir(os.path.join(image_directory, 'output'))
 
         print 'Making "%s" from "%s"' % (image_filename, image_directory)
-        os.system('virt-make-fs --size=10M --format=qcow2 %s %s' % (image_directory, image_filename))
+        os.system('virt-make-fs --size=10M --format=raw %s %s' % (image_directory, image_filename))
         shutil.rmtree(image_directory)
 
         contents_to_filename[config_contents] = image_filename

--- a/bin/process-job-output
+++ b/bin/process-job-output
@@ -6,10 +6,10 @@ job_id=$2
 # Remove this job's input image, which is no longer needed.  Because input
 # images are hardlinked, there are no race conditions among jobs and their
 # linked input images.
-unlink input-image-$serial.qcow2
+unlink input-image-$serial.dsk
 
 # Extract all files from the output image and remove the output image
-../bin/extract-job-output result-image-$serial.qcow2 output-$serial
+../bin/extract-job-output result-image-$serial.dsk output-$serial
 
 # Analyze output files
 ../bin/analyze_job_output.py $serial $job_id > output-$serial/analysis.yaml

--- a/jobs/single-test-run.sub
+++ b/jobs/single-test-run.sub
@@ -20,10 +20,10 @@ requirements            = ((HasGluster == True) && (HasVirshDefaultNetwork =?= T
 log                     = osg-test.log
 
 should_transfer_files   = YES
-transfer_input_files    = file:///mnt/gluster/chtc/VMs/$(platform)_htcondor.dsk,input-image-$(serial).qcow2
-vm_disk                 = $(platform)_htcondor.dsk:vda:w:raw,input-image-$(serial).qcow2:vdb:w:qcow2
+transfer_input_files    = file:///mnt/gluster/chtc/VMs/$(platform)_htcondor.dsk,input-image-$(serial).dsk
+vm_disk                 = $(platform)_htcondor.dsk:vda:w:raw,input-image-$(serial).dsk:vdb:w:raw
 when_to_transfer_output = ON_EXIT
-transfer_output_files   = input-image-$(serial).qcow2
-transfer_output_remaps  = "input-image-$(serial).qcow2 = result-image-$(serial).qcow2"
+transfer_output_files   = input-image-$(serial).dsk
+transfer_output_remaps  = "input-image-$(serial).dsk = result-image-$(serial).dsk"
 
 queue

--- a/jobs/single-test-run.sub
+++ b/jobs/single-test-run.sub
@@ -15,12 +15,12 @@ periodic_release        = ( (HoldReasonCode == 3) && (NumJobStarts < 3) ) || ( (
 periodic_remove         = ( (JobStatus == 5) && (HoldReasonCode =?= 3) && (NumJobStarts >= 3) ) || (time() - QDate >  43200)
 
 request_disk            = 8GB
-requirements            = ((HasGluster == True) && (HasVirshDefaultNetwork =?= True))
+requirements            = (HasVirshDefaultNetwork =?= True)
 
 log                     = osg-test.log
 
 should_transfer_files   = YES
-transfer_input_files    = file:///mnt/gluster/chtc/VMs/$(platform)_htcondor.dsk,input-image-$(serial).dsk
+transfer_input_files    = /mnt/gluster/chtc/VMs/$(platform)_htcondor.dsk,input-image-$(serial).dsk
 vm_disk                 = $(platform)_htcondor.dsk:vda:w:raw,input-image-$(serial).dsk:vdb:w:raw
 when_to_transfer_output = ON_EXIT
 transfer_output_files   = input-image-$(serial).dsk


### PR DESCRIPTION
https://github.com/opensciencegrid/vm-test-runs/commit/b49d771ae8586fce182be74dce0d5f6fc078471d can be reverted when either one of the following happens:

1. CHTC EL7 nodes are updated to the release version for 8.9.4
2. EL6 nodes have their VMU capabilities restored

Relevant RT ticket: https://crt.cs.wisc.edu/rt/Ticket/Display.html?id=98983