### PR TITLE
Add globus-gass-copy-progs and uberftp to the GridFTP tests for 3.5

### DIFF
--- a/parameters.d/osg35.yaml
+++ b/parameters.d/osg35.yaml
@@ -49,6 +49,8 @@ package_sets:
     packages:
       - osg-gridftp
       - osg-gridftp-xrootd
+      - globus-gass-copy-progs
+      - uberftp
   - label: CVMFS + Singularity
     packages:
       - osg-oasis


### PR DESCRIPTION
SOFTWARE-3946

There is no corresponding change for the prerelease tests because they only test osg-tested-internal (and there's a separate ticket for that: SOFTWARE-3945)