### PR TITLE
Fix git branch regex

### DIFF
--- a/bin/osg-run-tests
+++ b/bin/osg-run-tests
@@ -55,7 +55,7 @@ set_parameters_base()
 
 set_github_info()
 {
-    if [[ "$1" =~ ^[A-Za-z0-9_-]*:[A-Za-z0-9_-/]*$ ]]; then
+    if [[ "$1" =~ ^[A-Za-z0-9_-]*:[/A-Za-z0-9_-]*$ ]]; then
         GH_ACCOUNT="${1%:*}"
         GH_BRANCH="${1#*:}"
     else


### PR DESCRIPTION
Putting the `/` after the `-` turned it into the range `_-/`, which is backwards (`/` is before `_` in the ASCII table) and broken.