### PR TITLE
Keep fewer runs around since we keep io images on failed runs

### DIFF
--- a/bin/vm-test-cleanup
+++ b/bin/vm-test-cleanup
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RUNS_TO_KEEP=400
+RUNS_TO_KEEP=300
 
 year='20[1-9][0-9]'
 month='[01][0-9]'


### PR DESCRIPTION
A small bandaid.