### PR TITLE
Drop EL8 osg-xrootd-gridftp from the tests

### DIFF
--- a/parameters.d/osg35-el8-testing.yaml
+++ b/parameters.d/osg35-el8-testing.yaml
@@ -74,7 +74,7 @@ package_sets:
 #      - lcmaps-db-templates
 #      - vo-client-lcmaps-voms
 #      - globus-proxy-utils # proxy required for all transfer tests
-  - label: XRootD Plugins
+  - label: XRootD Plugins (minus GridFTP)
     packages:
       - xrootd
       - xrootd-multiuser
@@ -85,7 +85,6 @@ package_sets:
       - lcmaps-db-templates
       - vo-client-lcmaps-voms
       - globus-proxy-utils
-      - osg-gridftp-xrootd
   - label: StashCache
     packages:
       - stashcache-client

--- a/parameters.d/osg35-el8.yaml
+++ b/parameters.d/osg35-el8.yaml
@@ -73,7 +73,7 @@ package_sets:
 #      - lcmaps-db-templates
 #      - vo-client-lcmaps-voms
 #      - globus-proxy-utils # proxy required for all transfer tests
-#  - label: XRootD Plugins
+#  - label: XRootD Plugins (minus GridFTP)
 #    packages:
 #      - xrootd
 #      - xrootd-multiuser
@@ -84,7 +84,6 @@ package_sets:
 #      - lcmaps-db-templates
 #      - vo-client-lcmaps-voms
 #      - globus-proxy-utils
-#      - osg-gridftp-xrootd
 #  - label: StashCache
 #    packages:
 #      - stashcache-client


### PR DESCRIPTION
We have the other plugins built but nothing GridFTP-related yet and
it's preventing us from getting past the install step