### PR TITLE
Split 'All" tests into logical subsets (SOFTWARE-4289)

### DIFF
--- a/parameters.d-prerelease/osg34-el7-only.yaml
+++ b/parameters.d-prerelease/osg34-el7-only.yaml
@@ -39,4 +39,10 @@ package_sets:
       - lcmaps-db-templates
       - vo-client-lcmaps-voms
       - globus-proxy-utils # proxy required for all transfer tests
-
+  - label: VOMS
+    packages:
+      - voms-server
+      - voms-clients
+      - voms-mysql-plugin
+      - mariadb
+      - mariadb-server

--- a/parameters.d-prerelease/osg34-el7-only.yaml
+++ b/parameters.d-prerelease/osg34-el7-only.yaml
@@ -6,6 +6,24 @@ sources:
   - opensciencegrid:master; 3.4; osg-prerelease
 
 package_sets:
+  - label: StashCache
+    packages:
+      - stashcache-client
+      - stash-cache
+      - stash-origin
+      - globus-proxy-utils
+      - gfal2-util
+      - gfal2-all
+  - label: XRootD
+    packages:
+      - osg-xrootd-standalone
+      - xrootd-multiuser
+      - xrootd-client
+      - xrootd-fuse
+      - xrootd-scitokens
+      - globus-proxy-utils
+      - osg-gridftp-xrootd
+      - x509-scitokens-issuer-client
   - label: HDFS Plugins
     packages:
       - osg-gridftp-hdfs
@@ -14,27 +32,11 @@ package_sets:
       - gfal2-util
       - gfal2-plugin-file
   #disabled (SOFTWARE-3431)
-  #    - xrootd
-  #    - xrootd-hdfs
-  #    - xrootd-client
-  #    - xrootd-lcmaps
+  #      - xrootd
+  #      - xrootd-hdfs
+  #      - xrootd-client
+  #      - xrootd-lcmaps
       - lcmaps-db-templates
       - vo-client-lcmaps-voms
       - globus-proxy-utils # proxy required for all transfer tests
-  - label: XRootD Plugins
-    packages:
-      - xrootd
-      - xrootd-multiuser
-      - xrootd-lcmaps
-      - xrootd-client
-      - xrootd-fuse
-      - xrootd-scitokens
-      - lcmaps-db-templates
-      - vo-client-lcmaps-voms
-      - globus-proxy-utils
-      - osg-gridftp-xrootd
-  - label: StashCache
-    packages:
-      - stashcache-client
-      - stash-cache
-      - stash-origin
+

--- a/parameters.d-prerelease/osg34.yaml
+++ b/parameters.d-prerelease/osg34.yaml
@@ -9,6 +9,41 @@ sources:
   - opensciencegrid:master; 3.4; osg > osg-prerelease
 
 package_sets:
-  - label: All
+  - label: Compute Entrypoint
     packages:
-      - osg-tested-internal
+      - osg-ce-condor
+      - torque-server
+      - torque-mom
+      - torque-client
+      - torque-scheduler
+      - slurm
+      - slurm-slurmd
+      - slurm-slurmctld
+      - slurm-perlapi
+      - slurm-slurmdbd
+      - globus-proxy-utils
+  - label: Worker Node
+    packages:
+      - osg-wn-client
+      - osg-oasis
+      - singularity
+  - label: GridFTP (3.4)
+    packages:
+      - osg-gridftp
+      - osg-gridftp-xrootd
+      - rsv
+  - label: GSI OpenSSH
+    packages:
+      - gsi-openssh-server
+      - gsi-openssh-clients
+  - label: MyProxy
+    packages:
+      - myproxy
+      - myproxy-server
+  - label: GlideinwmsFrontend
+    packages:
+      - glideinwms-vofrontend
+  - label: GlideinwmsFactory
+    packages:
+      - glideinwms-factory
+

--- a/parameters.d-prerelease/osg35-el8.yaml
+++ b/parameters.d-prerelease/osg35-el8.yaml
@@ -8,6 +8,9 @@ sources:
   - opensciencegrid:master; 3.5; osg > osg-prerelease, osg-upcoming-prerelease, osg-upcoming
 
 package_sets:
-  - label: All
+  - label: Worker Node
     packages:
-      - osg-tested-internal
+      - osg-wn-client
+      - osg-oasis
+      - singularity
+

--- a/parameters.d-prerelease/osg35.yaml
+++ b/parameters.d-prerelease/osg35.yaml
@@ -11,6 +11,75 @@ sources:
   - opensciencegrid:master; 3.5; osg > osg-prerelease, osg-upcoming-prerelease, osg-upcoming
 
 package_sets:
-  - label: All
+  - label: Compute Entrypoint
     packages:
-      - osg-tested-internal
+      - osg-ce-condor
+      - torque-server
+      - torque-mom
+      - torque-client
+      - torque-scheduler
+      - slurm
+      - slurm-slurmd
+      - slurm-slurmctld
+      - slurm-perlapi
+      - slurm-slurmdbd
+      - globus-proxy-utils
+  - label: Worker Node
+    packages:
+      - osg-wn-client
+      - osg-oasis
+      - singularity
+  - label: StashCache
+    packages:
+      - stashcache-client
+      - stash-cache
+      - stash-origin
+      - globus-proxy-utils
+      - gfal2-util
+      - gfal2-all
+  - label: XRootD
+    packages:
+      - osg-xrootd-standalone
+      - xrootd-multiuser
+      - xrootd-client
+      - xrootd-fuse
+      - xrootd-scitokens
+      - globus-proxy-utils
+      - osg-gridftp-xrootd
+      - x509-scitokens-issuer-client
+  - label: GridFTP
+    packages:
+      - osg-gridftp
+      - osg-gridftp-xrootd
+      - globus-gass-copy-progs
+      - uberftp
+      - globus-proxy-utils  # proxy required for all transfer tests
+  - label: HDFS Plugins
+    packages:
+      - osg-gridftp-hdfs
+      - globus-gass-copy-progs
+      - gfal2-plugin-gridftp
+      - gfal2-util
+      - gfal2-plugin-file
+  #disabled (SOFTWARE-3431)
+  #    - xrootd
+  #    - xrootd-hdfs
+  #    - xrootd-client
+  #    - xrootd-lcmaps
+      - lcmaps-db-templates
+      - vo-client-lcmaps-voms
+      - globus-proxy-utils # proxy required for all transfer tests
+  - label: GSI OpenSSH
+    packages:
+      - gsi-openssh-server
+      - gsi-openssh-clients
+  - label: MyProxy
+    packages:
+      - myproxy
+      - myproxy-server
+  - label: GlideinwmsFrontend
+    packages:
+      - glideinwms-vofrontend
+  - label: GlideinwmsFactory
+    packages:
+      - glideinwms-factory

--- a/parameters.d-prerelease/osg35.yaml
+++ b/parameters.d-prerelease/osg35.yaml
@@ -83,3 +83,10 @@ package_sets:
   - label: GlideinwmsFactory
     packages:
       - glideinwms-factory
+  - label: VOMS
+    packages:
+      - voms-server
+      - voms-clients
+      - voms-mysql-plugin
+      - mariadb
+      - mariadb-server

--- a/parameters.d/osg34-el7-only.yaml
+++ b/parameters.d/osg34-el7-only.yaml
@@ -31,7 +31,24 @@ package_sets:
   # osg_java - Pre-install OSG java packages (default: False)
   # rng - Install entropy generation package (default: False)
   ##################
-
+  - label: StashCache
+    packages:
+      - stashcache-client
+      - stash-cache
+      - stash-origin
+      - globus-proxy-utils
+      - gfal2-util
+      - gfal2-all
+  - label: XRootD
+    packages:
+      - osg-xrootd-standalone
+      - xrootd-multiuser
+      - xrootd-client
+      - xrootd-fuse
+      - xrootd-scitokens
+      - globus-proxy-utils
+      - osg-gridftp-xrootd
+      - x509-scitokens-issuer-client
   - label: HDFS Plugins
     packages:
       - osg-gridftp-hdfs
@@ -47,25 +64,4 @@ package_sets:
       - lcmaps-db-templates
       - vo-client-lcmaps-voms
       - globus-proxy-utils # proxy required for all transfer tests
-  - label: XRootD Plugins
-    packages:
-      - xrootd
-      - xrootd-multiuser
-      - xrootd-lcmaps
-      - xrootd-client
-      - xrootd-fuse
-      - xrootd-scitokens
-      - lcmaps-db-templates
-      - vo-client-lcmaps-voms
-      - globus-proxy-utils
-      - osg-gridftp-xrootd
-      - osg-xrootd-standalone
-      - x509-scitokens-issuer-client
-  - label: StashCache
-    packages:
-      - stashcache-client
-      - stash-cache
-      - stash-origin
-      - globus-proxy-utils
-      - gfal2-util
-      - gfal2-all
+

--- a/parameters.d/osg34-el7-only.yaml
+++ b/parameters.d/osg34-el7-only.yaml
@@ -64,4 +64,10 @@ package_sets:
       - lcmaps-db-templates
       - vo-client-lcmaps-voms
       - globus-proxy-utils # proxy required for all transfer tests
-
+  - label: VOMS
+    packages:
+      - voms-server
+      - voms-clients
+      - voms-mysql-plugin
+      - mariadb
+      - mariadb-server

--- a/parameters.d/osg34.yaml
+++ b/parameters.d/osg34.yaml
@@ -33,23 +33,37 @@ package_sets:
   # osg_java - Pre-install OSG java packages (default: False)
   # rng - Install entropy generation package (default: False)
   ##################
-  - label: All
+  - label: Compute Entrypoint
     packages:
-      - osg-tested-internal
-  - label: HTCondor
-    packages:
-      - condor.x86_64
       - osg-ce-condor
-      - rsv
-  - label: GridFTP
+      - torque-server
+      - torque-mom
+      - torque-client
+      - torque-scheduler
+      - slurm
+      - slurm-slurmd
+      - slurm-slurmctld
+      - slurm-perlapi
+      - slurm-slurmdbd
+      - globus-proxy-utils
+  - label: Worker Node
+    packages:
+      - osg-wn-client
+      - osg-oasis
+      - singularity
+  - label: GridFTP (3.4)
     packages:
       - osg-gridftp
       - osg-gridftp-xrootd
       - rsv
-  - label: CVMFS + Singularity
+  - label: GSI OpenSSH
     packages:
-      - osg-oasis
-      - singularity
+      - gsi-openssh-server
+      - gsi-openssh-clients
+  - label: MyProxy
+    packages:
+      - myproxy
+      - myproxy-server
   ###########################
   #- label: GlideinwmsFrontend
   #  packages:

--- a/parameters.d/osg35-el8-testing.yaml
+++ b/parameters.d/osg35-el8-testing.yaml
@@ -37,25 +37,11 @@ package_sets:
   # osg_java - Pre-install OSG java packages (default: False)
   # rng - Install entropy generation package (default: False)
   ##################
-
-  - label: CVMFS + Singularity
-    packages:
-      - osg-oasis
-      - singularity
-  - label: osg-wn-client
+  - label: Worker Node
     packages:
       - osg-wn-client
-  - label: XRootD Plugins (minus GridFTP)
-    packages:
-      - xrootd
-      - xrootd-multiuser
-      - xrootd-lcmaps
-      - xrootd-client
-      - xrootd-fuse
-      - xrootd-scitokens
-      - lcmaps-db-templates
-      - vo-client-lcmaps-voms
-      - globus-proxy-utils
+      - osg-oasis
+      - singularity
   - label: StashCache
     packages:
       - stashcache-client
@@ -64,17 +50,30 @@ package_sets:
       - globus-proxy-utils
       - gfal2-util
       - gfal2-all
-
+  - label: XRootD (minus GridFTP)
+    packages:
+      - osg-xrootd-standalone
+      - xrootd-multiuser
+      - xrootd-client
+      - xrootd-fuse
+      - xrootd-scitokens
+      - globus-proxy-utils
+      - x509-scitokens-issuer-client
 ### The following tests have been disabled until the required packages are available.
-#  - label: All
+#  - label: Compute Entrypoint
 #    packages:
-#      - osg-tested-internal
-#  - label: HTCondor (3.5)
-#    packages:
-#      - condor
 #      - osg-ce-condor
-#      - globus-proxy-utils  # proxy required for job submission
-#  - label: GridFTP (3.5)
+#      - torque-server
+#      - torque-mom
+#      - torque-client
+#      - torque-scheduler
+#      - slurm
+#      - slurm-slurmd
+#      - slurm-slurmctld
+#      - slurm-perlapi
+#      - slurm-slurmdbd
+#      - globus-proxy-utils
+#  - label: GridFTP
 #    packages:
 #      - osg-gridftp
 #      - osg-gridftp-xrootd

--- a/parameters.d/osg35-el8.yaml
+++ b/parameters.d/osg35-el8.yaml
@@ -36,71 +36,8 @@ package_sets:
   # osg_java - Pre-install OSG java packages (default: False)
   # rng - Install entropy generation package (default: False)
   ##################
-  - label: CVMFS + Singularity
-    packages:
-      - osg-oasis
-      - singularity
-  - label: osg-wn-client
+  - label: Worker Node
     packages:
       - osg-wn-client
-
-### The following tests have been disabled until the required packages are available.
-#  - label: All
-#    packages:
-#      - osg-tested-internal
-#  - label: HTCondor (3.5)
-#    packages:
-#      - condor
-#      - osg-ce-condor
-#      - globus-proxy-utils  # proxy required for job submission
-#  - label: GridFTP (3.5)
-#    packages:
-#      - osg-gridftp
-#      - osg-gridftp-xrootd
-#      - globus-gass-copy-progs
-#      - uberftp
-#      - globus-proxy-utils  # proxy required for all transfer tests
-#  - label: HDFS Plugins
-#    packages:
-#      - osg-gridftp-hdfs
-#      - globus-gass-copy-progs
-#      - gfal2-plugin-gridftp
-#      - gfal2-util
-#      - gfal2-plugin-file
-#  #disabled (SOFTWARE-3431)
-#  #    - xrootd
-#  #    - xrootd-hdfs
-#  #    - xrootd-client
-#  #    - xrootd-lcmaps
-#      - lcmaps-db-templates
-#      - vo-client-lcmaps-voms
-#      - globus-proxy-utils # proxy required for all transfer tests
-#  - label: XRootD Plugins (minus GridFTP)
-#    packages:
-#      - xrootd
-#      - xrootd-multiuser
-#      - xrootd-lcmaps
-#      - xrootd-client
-#      - xrootd-fuse
-#      - xrootd-scitokens
-#      - lcmaps-db-templates
-#      - vo-client-lcmaps-voms
-#      - globus-proxy-utils
-#      - osg-xrootd-standalone
-#      - x509-scitokens-issuer-client
-#  - label: StashCache
-#    packages:
-#      - stashcache-client
-#      - stash-cache
-#      - stash-origin
-#      - globus-proxy-utils
-#      - gfal2-util
-#      - gfal2-all
-  ###########################
-  #- label: GlideinwmsFrontend
-  #  packages:
-  #    - glideinwms-vofrontend
-  #- label: GlideinwmsFactory
-  #  packages:
-  #    - glideinwms-factory
-
+      - osg-oasis
+      - singularity

--- a/parameters.d/osg35.yaml
+++ b/parameters.d/osg35.yaml
@@ -103,6 +103,13 @@ package_sets:
     packages:
       - myproxy
       - myproxy-server
+  - label: VOMS
+    packages:
+      - voms-server
+      - voms-clients
+      - voms-mysql-plugin
+      - mariadb
+      - mariadb-server
   ###########################
   #- label: GlideinwmsFrontend
   #  packages:

--- a/parameters.d/osg35.yaml
+++ b/parameters.d/osg35.yaml
@@ -37,25 +37,49 @@ package_sets:
   # osg_java - Pre-install OSG java packages (default: False)
   # rng - Install entropy generation package (default: False)
   ##################
-  - label: All
+  - label: Compute Entrypoint
     packages:
-      - osg-tested-internal
-  - label: HTCondor (3.5)
-    packages:
-      - condor
       - osg-ce-condor
-      - globus-proxy-utils  # proxy required for job submission
-  - label: GridFTP (3.5)
+      - torque-server
+      - torque-mom
+      - torque-client
+      - torque-scheduler
+      - slurm
+      - slurm-slurmd
+      - slurm-slurmctld
+      - slurm-perlapi
+      - slurm-slurmdbd
+      - globus-proxy-utils
+  - label: Worker Node
+    packages:
+      - osg-wn-client
+      - osg-oasis
+      - singularity
+  - label: StashCache
+    packages:
+      - stashcache-client
+      - stash-cache
+      - stash-origin
+      - globus-proxy-utils
+      - gfal2-util
+      - gfal2-all
+  - label: XRootD
+    packages:
+      - osg-xrootd-standalone
+      - xrootd-multiuser
+      - xrootd-client
+      - xrootd-fuse
+      - xrootd-scitokens
+      - globus-proxy-utils
+      - osg-gridftp-xrootd
+      - x509-scitokens-issuer-client
+  - label: GridFTP
     packages:
       - osg-gridftp
       - osg-gridftp-xrootd
       - globus-gass-copy-progs
       - uberftp
       - globus-proxy-utils  # proxy required for all transfer tests
-  - label: CVMFS + Singularity
-    packages:
-      - osg-oasis
-      - singularity
   - label: HDFS Plugins
     packages:
       - osg-gridftp-hdfs
@@ -71,28 +95,14 @@ package_sets:
       - lcmaps-db-templates
       - vo-client-lcmaps-voms
       - globus-proxy-utils # proxy required for all transfer tests
-  - label: XRootD Plugins
+  - label: GSI OpenSSH
     packages:
-      - xrootd
-      - xrootd-multiuser
-      - xrootd-lcmaps
-      - xrootd-client
-      - xrootd-fuse
-      - xrootd-scitokens
-      - lcmaps-db-templates
-      - vo-client-lcmaps-voms
-      - globus-proxy-utils
-      - osg-gridftp-xrootd
-      - osg-xrootd-standalone
-      - x509-scitokens-issuer-client
-  - label: StashCache
+      - gsi-openssh-server
+      - gsi-openssh-clients
+  - label: MyProxy
     packages:
-      - stashcache-client
-      - stash-cache
-      - stash-origin
-      - globus-proxy-utils
-      - gfal2-util
-      - gfal2-all
+      - myproxy
+      - myproxy-server
   ###########################
   #- label: GlideinwmsFrontend
   #  packages:


### PR DESCRIPTION
Results here: https://osg-sw-submit.chtc.wisc.edu/tests/20201110-1821/results.html

1. Embarassingly we weren't testing osg-wn-client in the nightlies and our tests are failing as expected.
1. The MyProxy package set is failing to install because of a failed `rpm -q --verify`, which we weren't catching in the "All" tests. I think is due to how we decide on which packages to verify in `osg-test`



