### PR TITLE
Add EPEL testing runs to the nightlies (SOFTWARE-3910)

### DIFF
--- a/bin/vmu.py
+++ b/bin/vmu.py
@@ -94,6 +94,7 @@ def canonical_src_string(sources):
     m = re.search(r'(^\w+:[./\w-]+)\s*;\s*(.*)', result)
     if m:
         branch, result = m.groups()
+    result = re.sub(r'epel-testing', 'EPEL Testing', result)
     result = re.sub(r'osg-minefield', 'Minefield', result)
     result = re.sub(r'osg-development', 'Development', result)
     result = re.sub(r'osg-testing', 'Testing', result)

--- a/parameters.d/osg34-el7-only.yaml
+++ b/parameters.d/osg34-el7-only.yaml
@@ -18,6 +18,7 @@ sources:
   # 3.2; osg, osg-testing > 3.3/osg-testing, osg-upcoming-testing
   ###################
   - opensciencegrid:master; 3.4; osg
+  - opensciencegrid:master; 3.4; osg, epel-testing
   - opensciencegrid:master; 3.4; osg-rolling
   - opensciencegrid:master; 3.4; osg-testing
   - opensciencegrid:master; 3.4; osg > osg-testing

--- a/parameters.d/osg34.yaml
+++ b/parameters.d/osg34.yaml
@@ -20,6 +20,7 @@ sources:
   # 3.2; osg, osg-testing > 3.3/osg-testing, osg-upcoming-testing
   ###################
   - opensciencegrid:master; 3.4; osg
+  - opensciencegrid:master; 3.4; osg, epel-testing
   - opensciencegrid:master; 3.4; osg-rolling
   - opensciencegrid:master; 3.4; osg-testing
   - opensciencegrid:master; 3.4; osg > osg-testing

--- a/parameters.d/osg35-el8.yaml
+++ b/parameters.d/osg35-el8.yaml
@@ -17,6 +17,7 @@ sources:
   # 3.2; osg, osg-testing > 3.3/osg-testing, osg-upcoming-testing
   ###################
   - opensciencegrid:master; 3.5; osg
+  - opensciencegrid:master; 3.5; osg, epel-testing
   - opensciencegrid:master; 3.5; osg > osg-testing
 #  - opensciencegrid:master; 3.5; osg
 #  - opensciencegrid:master; 3.5; osg-rolling

--- a/parameters.d/osg35.yaml
+++ b/parameters.d/osg35.yaml
@@ -18,12 +18,15 @@ sources:
   # 3.2; osg, osg-testing > 3.3/osg-testing, osg-upcoming-testing
   ###################
   - opensciencegrid:master; 3.5; osg
+  - opensciencegrid:master; 3.5; osg, epel-testing
   - opensciencegrid:master; 3.5; osg-rolling
   - opensciencegrid:master; 3.5; osg-testing
   - opensciencegrid:master; 3.5; osg > osg-testing
   - opensciencegrid:master; 3.4; osg > 3.5/osg
+  - opensciencegrid:master; 3.4; osg > 3.5/osg, epel-testing
   - opensciencegrid:master; 3.4; osg-testing > 3.5/osg-testing
   - opensciencegrid:master; 3.5; osg, osg-upcoming
+  - opensciencegrid:master; 3.5; osg, osg-upcoming, epel-testing
   - opensciencegrid:master; 3.5; osg-rolling, osg-upcoming-rolling
   - opensciencegrid:master; 3.5; osg-testing, osg-upcoming-testing
   - opensciencegrid:master; 3.5; osg > osg-testing, osg-upcoming-testing


### PR DESCRIPTION
Results here: https://osg-sw-submit.chtc.wisc.edu/tests/20201110-1728/results.html

Release + epel-testing failing to run condor jobs in the "All" tests is a little concerning but I think that's something that actually warrants digging, i.e. the tests are working.