### PR TITLE
Force python3 osgtest, retire EOL OSes

### DIFF
--- a/bin/run-job
+++ b/bin/run-job
@@ -51,13 +51,13 @@ case $os_major_version in
         osg_url="https://repo.opensciencegrid.org/osg/$osg_series/osg-$osg_series-el7-release-latest.rpm"
         priorities_rpm='yum-plugin-priorities'
         python_lib_dir='/usr/lib/python2.7'
-        python='/usr/bin/python2'
+        python='/usr/bin/python3'
         ;;
     8 )
         osg_url="https://repo.opensciencegrid.org/osg/$osg_series/osg-$osg_series-el8-release-latest.rpm"
         priorities_rpm=
         python_lib_dir='/usr/lib/python3.6'
-        python='/usr/libexec/platform-python'
+        python='/usr/bin/python3'
         ;;
     * )
         echo "Could not determine OS major version from '$os_major_version'"
@@ -123,6 +123,9 @@ if [ $? -ne 0 ]; then
     log_command echo 'Could not install OSG repository'
     exit 1
 fi
+
+# Install Python 3
+run_command_with_retries 8 yum -y install python3 python3-rpm
 
 # Install osg-test and osg-ca-generator
 if [ -f $INPUT_DIR/osg-test-git.tar.gz ]; then

--- a/bin/run-job
+++ b/bin/run-job
@@ -50,7 +50,7 @@ case $os_major_version in
     7 )
         osg_url="https://repo.opensciencegrid.org/osg/$osg_series/osg-$osg_series-el7-release-latest.rpm"
         priorities_rpm='yum-plugin-priorities'
-        python_lib_dir='/usr/lib/python2.7'
+        python_lib_dir='/usr/lib/python3.6'
         python='/usr/bin/python3'
         ;;
     8 )

--- a/bin/run-job
+++ b/bin/run-job
@@ -47,17 +47,6 @@ osg_series=`grep series $INPUT_DIR/osg-test.conf | sed -e 's/series *= *//'`
 os_major_version=`sed -e 's/^[^0-9]*//' -e 's/\..*$//' /etc/redhat-release`
 epel_url="https://dl.fedoraproject.org/pub/epel/epel-release-latest-$os_major_version.noarch.rpm"
 case $os_major_version in
-    5 )
-        osg_url="https://repo.opensciencegrid.org/osg/$osg_series/osg-$osg_series-el5-release-latest.rpm"
-        priorities_rpm='yum-priorities'
-        python_lib_dir='/usr/lib/python2.4'
-        ;;
-    6 )
-        osg_url="https://repo.opensciencegrid.org/osg/$osg_series/osg-$osg_series-el6-release-latest.rpm"
-        priorities_rpm='yum-plugin-priorities'
-        python_lib_dir='/usr/lib/python2.6'
-        python='/usr/bin/python2'
-        ;;
     7 )
         osg_url="https://repo.opensciencegrid.org/osg/$osg_series/osg-$osg_series-el7-release-latest.rpm"
         priorities_rpm='yum-plugin-priorities'


### PR DESCRIPTION
I used these changes for this run: https://osg-sw-submit.chtc.wisc.edu/tests/20210225-1050/results.html