### PR TITLE
Add EL8 CE tests

### DIFF
--- a/parameters.d/osg35-el8-testing.yaml
+++ b/parameters.d/osg35-el8-testing.yaml
@@ -61,22 +61,18 @@ package_sets:
       - xrootd-scitokens
       - globus-proxy-utils
       - x509-scitokens-issuer-client
+ - label: Compute Entrypoint (no Torque)
+   packages:
+     - osg-ce-condor
+     - htcondor-ce-view
+     - slurm
+     - slurm-slurmd
+     - slurm-slurmctld
+     - slurm-perlapi
+     - slurm-slurmdbd
+     - mariadb-server
+     - globus-proxy-utils
 ### The following tests have been disabled until the required packages are available.
-#  - label: Compute Entrypoint
-#    packages:
-#      - osg-ce-condor
-#      - htcondor-ce-view
-#      - torque-server
-#      - torque-mom
-#      - torque-client
-#      - torque-scheduler
-#      - slurm
-#      - slurm-slurmd
-#      - slurm-slurmctld
-#      - slurm-perlapi
-#      - slurm-slurmdbd
-#      - mariadb-server
-#      - globus-proxy-utils
 #  - label: Central Collector
 #    packages:
 #      - htcondor-ce-collector

--- a/parameters.d/osg36-el8.yaml
+++ b/parameters.d/osg36-el8.yaml
@@ -34,20 +34,16 @@ package_sets:
   # osg_java - Pre-install OSG java packages (default: False)
   # rng - Install entropy generation package (default: False)
   ##################
-  # - label: Compute Entrypoint (3.6)
-  #   packages:
-  #     - osg-ce-condor
-  #     - htcondor-ce-view
-  #     - torque-server
-  #     - torque-mom
-  #     - torque-client
-  #     - torque-scheduler
-  #     - slurm
-  #     - slurm-slurmd
-  #     - slurm-slurmctld
-  #     - slurm-perlapi
-  #     - slurm-slurmdbd
-  #     - mariadb-server
+  - label: Compute Entrypoint (no Globus/Torque)
+    packages:
+      - osg-ce-condor
+      - htcondor-ce-view
+      - slurm
+      - slurm-slurmd
+      - slurm-slurmctld
+      - slurm-perlapi
+      - slurm-slurmdbd
+      - mariadb-server
   # - label: Central Collector
   #   packages:
   #     - htcondor-ce-collector

--- a/parameters.d/osg36.yaml
+++ b/parameters.d/osg36.yaml
@@ -36,7 +36,7 @@ package_sets:
   # osg_java - Pre-install OSG java packages (default: False)
   # rng - Install entropy generation package (default: False)
   ##################
-  - label: Compute Entrypoint (3.6)
+  - label: Compute Entrypoint (no Globus)
     packages:
       - osg-ce-condor
       - htcondor-ce-view


### PR DESCRIPTION
1.  3.6 doesn't have Globus
2.  EPEL8 doesn't contain Torque

We used the EL8 params here: https://osg-sw-submit.chtc.wisc.edu/tests/20210427-0717/results.html. I didn't add the central collector package set because I haven't decided how to address that `mod_auth_openidc` is only available through modules