### PR TITLE
except for this one

### DIFF
--- a/vmu.css
+++ b/vmu.css
@@ -23,7 +23,6 @@ td.result a {
   text-decoration:none;
   font-family:monospace;
   color:black;
-  background-color:white;
 }
 
 /* Test result colors */


### PR DESCRIPTION
the `<a>` inside a `<td class=result>` inherits the surrounding bg color, which is not white.

looks good for me now for the vmu results pages