### PR TITLE
allow empty params files

### DIFF
--- a/bin/vmu.py
+++ b/bin/vmu.py
@@ -46,7 +46,7 @@ def load_run_params(param_dir):
             # skip non-yaml files
             pass
         else:
-            if set(param_contents) == set(['platforms', 'sources', 'package_sets']):
+            if param_contents and set(param_contents) == set(['platforms', 'sources', 'package_sets']):
                 param_contents['package_sets'] = [PackageSet.from_dict(x) for x in param_contents['package_sets']]
                 run_params.append(param_contents)
     if not run_params:


### PR DESCRIPTION
the intention of the surrounding code is to ignore files that do not
parse as yaml.  However, an empty file under parameters.d gets parsed
as yaml.load("") -> None, and that None is not iterable by set()

So, change this 'if' condition not to raise an exception if
param_contents for a given yaml file is empty/None.