### PR TITLE
Pull in the Python 3 gfal2-util across all installs (SOFTWARE-4825)

### DIFF
--- a/parameters.d-prerelease/osg35.yaml
+++ b/parameters.d-prerelease/osg35.yaml
@@ -41,7 +41,7 @@ package_sets:
       - stash-cache
       - stash-origin
       - globus-proxy-utils
-      - gfal2-util
+      - python3-gfal2-util
       - gfal2-all
   - label: XRootD
     packages:
@@ -65,7 +65,7 @@ package_sets:
       - osg-gridftp-hdfs
       - globus-gass-copy-progs
       - gfal2-plugin-gridftp
-      - gfal2-util
+      - python3-gfal2-util
       - gfal2-plugin-file
   #disabled (SOFTWARE-3431)
   #    - xrootd

--- a/parameters.d-prerelease/osg36.yaml
+++ b/parameters.d-prerelease/osg36.yaml
@@ -39,7 +39,7 @@ package_sets:
   #     - stashcache-client
   #     - stash-cache
   #     - stash-origin
-  #     - gfal2-util
+  #     - python3-gfal2-util
   #     - gfal2-all
   # - label: XRootD (3.6)
   #   packages:

--- a/parameters.d/osg35-el8-upcoming.yaml
+++ b/parameters.d/osg35-el8-upcoming.yaml
@@ -49,7 +49,7 @@ package_sets:
       - stash-cache
       - stash-origin
       - globus-proxy-utils
-      - gfal2-util
+      - python3-gfal2-util
       - gfal2-all
   - label: XRootD (minus GridFTP)
     packages:

--- a/parameters.d/osg35.yaml
+++ b/parameters.d/osg35.yaml
@@ -69,7 +69,7 @@ package_sets:
       - stash-cache
       - stash-origin
       - globus-proxy-utils
-      - gfal2-util
+      - python3-gfal2-util
       - gfal2-all
   - label: XRootD
     packages:
@@ -93,7 +93,7 @@ package_sets:
       - osg-gridftp-hdfs
       - globus-gass-copy-progs
       - gfal2-plugin-gridftp
-      - gfal2-util
+      - python3-gfal2-util
       - gfal2-plugin-file
       - lcmaps-db-templates
       - vo-client-lcmaps-voms

--- a/parameters.d/osg36-el8.yaml
+++ b/parameters.d/osg36-el8.yaml
@@ -61,7 +61,7 @@ package_sets:
   #     - stashcache-client
   #     - stash-cache
   #     - stash-origin
-  #     - gfal2-util
+  #     - python3-gfal2-util
   #     - gfal2-all
   # - label: XRootD (3.6)
   #   packages:

--- a/parameters.d/osg36.yaml
+++ b/parameters.d/osg36.yaml
@@ -65,7 +65,7 @@ package_sets:
   #     - stashcache-client
   #     - stash-cache
   #     - stash-origin
-  #     - gfal2-util
+  #     - python3-gfal2-util
   #     - gfal2-all
   # - label: XRootD (3.6)
   #   packages:


### PR DESCRIPTION
Test results here https://osg-sw-submit.chtc.wisc.edu/tests/20210922-0855/packages.html (goes along with https://github.com/opensciencegrid/osg-test/pull/235)

`osg-wn-client` will be updated to pull in the right `gfal2-util` libs based on the OS version here: https://opensciencegrid.atlassian.net/browse/SOFTWARE-4826