### PR TITLE
Add voms requirements to xrootd for 3.6 tests

### DIFF
--- a/parameters.d/osg36-xrootd.yaml
+++ b/parameters.d/osg36-xrootd.yaml
@@ -56,3 +56,9 @@ package_sets:
       - osg-xrootd-standalone
       - xrootd-multiuser
       - xrootd-client
+      - voms-clients-cpp
+      # below required for setting up a voms server; not needed for voms-proxy-direct
+      - voms-server
+      - voms-mysql-plugin
+      - mariadb
+      - mariadb-server


### PR DESCRIPTION
We need voms-clients-cpp to get a voms proxy
We also need the server packages because our current tests don't use voms-proxy-direct to create the proxy
