### PR TITLE
Update xrootd 3.6 test parameters to use production repos

### DIFF
--- a/parameters.d-prerelease/osg36-xrootd.yaml
+++ b/parameters.d-prerelease/osg36-xrootd.yaml
@@ -15,6 +15,7 @@ sources:
   - opensciencegrid:xrootd-for-3.6; 3.6; osg-prerelease
   - opensciencegrid:xrootd-for-3.6; 3.6; osg > osg-prerelease
   - opensciencegrid:xrootd-for-3.6; 3.5; osg, osg-upcoming > 3.6/osg-prerelease
+  - opensciencegrid:xrootd-for-3.6; 3.5; osg > 3.6/osg-prerelease
 
 package_sets:
   #### Required ####

--- a/parameters.d-prerelease/osg36-xrootd.yaml
+++ b/parameters.d-prerelease/osg36-xrootd.yaml
@@ -39,8 +39,3 @@ package_sets:
       - xrootd-multiuser
       - xrootd-client
       - voms-clients-cpp
-      # below required for setting up a voms server; not needed for voms-proxy-direct
-      - voms-server
-      - voms-mysql-plugin
-      - mariadb
-      - mariadb-server

--- a/parameters.d/osg36-el7-xrootd.yaml
+++ b/parameters.d/osg36-el7-xrootd.yaml
@@ -1,0 +1,52 @@
+###################
+# OSG 3.6 tests for XRootD (EL7)
+# File format documention:
+# https://github.com/opensciencegrid/vm-test-runs#running-osg-test-in-vm-universe
+###################
+
+platforms:
+  - centos_7_x86_64
+  - sl_7_x86_64
+
+sources:
+  ###################
+  # Format:
+  # [<Github account>:<osg-test branch>;] <OSG ver>; <REPO 1, REPO 2...REPO N> [> <Update OSG ver>/<Update REPO 1, REPO 2...REPO N>]
+  # Example:
+  # Run osg-test (from 3.2-minefield) with packages from 3.2-release and 3.2-testing that are then upgraded to
+  # 3.3-testing and 3-3-upcoming-testing:
+  # 3.2; osg, osg-testing > 3.3/osg-testing, osg-upcoming-testing
+  ###################
+  - opensciencegrid:xrootd-for-3.6; 3.6; osg
+  - opensciencegrid:xrootd-for-3.6; 3.6; osg, epel-testing
+  - opensciencegrid:xrootd-for-3.6; 3.6; osg-testing
+  - opensciencegrid:xrootd-for-3.6; 3.6; osg > osg-testing
+  - opensciencegrid:xrootd-for-3.6; 3.5; osg > 3.6/osg
+  - opensciencegrid:xrootd-for-3.6; 3.5; osg, osg-upcoming > 3.6/osg
+  #- opensciencegrid:xrootd-for-3.6; 3.5; osg > 3.6/osg-minefield
+  #- opensciencegrid:xrootd-for-3.6; 3.5; osg, osg-upcoming > 3.6/osg-minefield
+  #- opensciencegrid:xrootd-for-3.6; 3.6; osg > osg-minefield
+  #- opensciencegrid:xrootd-for-3.6; 3.6; osg-minefield
+
+package_sets:
+  #### Required ####
+  # label - used for reporting, should be consistent across param files
+  # packages - list of packages to install in the test run
+  #### Optional ####
+  # selinux - enable SELinux for the package set, otherwise Permissive mode (default: True)
+  # osg_java - Pre-install OSG java packages (default: False)
+  # rng - Install entropy generation package (default: False)
+  ##################
+  - label: StashCache (3.6)
+    packages:
+      - stashcache-client
+      - stash-cache
+      - stash-origin
+      - python3-gfal2-util
+      - gfal2-all
+  - label: XRootD (3.6)
+    packages:
+      - osg-xrootd-standalone
+      - xrootd-multiuser
+      - xrootd-client
+      - voms-clients-cpp

--- a/parameters.d/osg36-el8-xrootd.yaml
+++ b/parameters.d/osg36-el8-xrootd.yaml
@@ -1,12 +1,10 @@
 ###################
-# OSG 3.6 tests for XRootD
+# OSG 3.6 tests for XRootD (EL8)
 # File format documention:
 # https://github.com/opensciencegrid/vm-test-runs#running-osg-test-in-vm-universe
 ###################
 
 platforms:
-  - centos_7_x86_64
-  - sl_7_x86_64
   - centos_8_x86_64
   - centos_stream_8_x86_64
   - rocky_8_x86_64
@@ -24,9 +22,7 @@ sources:
   - opensciencegrid:xrootd-for-3.6; 3.6; osg, epel-testing
   - opensciencegrid:xrootd-for-3.6; 3.6; osg-testing
   - opensciencegrid:xrootd-for-3.6; 3.6; osg > osg-testing
-  - opensciencegrid:xrootd-for-3.6; 3.5; osg > 3.6/osg
   - opensciencegrid:xrootd-for-3.6; 3.5; osg, osg-upcoming > 3.6/osg
-  #- opensciencegrid:xrootd-for-3.6; 3.5; osg > 3.6/osg-minefield
   #- opensciencegrid:xrootd-for-3.6; 3.5; osg, osg-upcoming > 3.6/osg-minefield
   #- opensciencegrid:xrootd-for-3.6; 3.6; osg > osg-minefield
   #- opensciencegrid:xrootd-for-3.6; 3.6; osg-minefield

--- a/parameters.d/osg36-xrootd.yaml
+++ b/parameters.d/osg36-xrootd.yaml
@@ -53,8 +53,3 @@ package_sets:
       - xrootd-multiuser
       - xrootd-client
       - voms-clients-cpp
-      # below required for setting up a voms server; not needed for voms-proxy-direct
-      - voms-server
-      - voms-mysql-plugin
-      - mariadb
-      - mariadb-server

--- a/parameters.d/osg36-xrootd.yaml
+++ b/parameters.d/osg36-xrootd.yaml
@@ -20,20 +20,16 @@ sources:
   # 3.3-testing and 3-3-upcoming-testing:
   # 3.2; osg, osg-testing > 3.3/osg-testing, osg-upcoming-testing
   ###################
-  # - opensciencegrid:master; 3.6; osg
-  # - opensciencegrid:master; 3.6; osg, epel-testing
-  # - opensciencegrid:master; 3.6; osg-testing
-  # - opensciencegrid:master; 3.6; osg > osg-testing
-  # - opensciencegrid:master; 3.5; osg > 3.6/osg
-  # - opensciencegrid:master; 3.6; osg, osg-upcoming
-  # - opensciencegrid:master; 3.6; osg, osg-upcoming, epel-testing
-  # - opensciencegrid:master; 3.6; osg-testing, osg-upcoming-testing
-  # - opensciencegrid:master; 3.6; osg > osg-testing, osg-upcoming-testing
-  - opensciencegrid:xrootd-for-3.6; 3.5; osg > 3.6/osg-minefield
-  - opensciencegrid:xrootd-for-3.6; 3.5; osg, osg-upcoming > 3.6/osg-minefield
-  - opensciencegrid:xrootd-for-3.6; 3.6; osg-minefield
-  #- opensciencegrid:xrootd-for-3.6; 3.6; osg-testing
-  #- opensciencegrid:xrootd-for-3.6; 3.6; osg-testing > osg-minefield
+  - opensciencegrid:xrootd-for-3.6; 3.6; osg
+  - opensciencegrid:xrootd-for-3.6; 3.6; osg, epel-testing
+  - opensciencegrid:xrootd-for-3.6; 3.6; osg-testing
+  - opensciencegrid:xrootd-for-3.6; 3.6; osg > osg-testing
+  - opensciencegrid:xrootd-for-3.6; 3.5; osg > 3.6/osg
+  - opensciencegrid:xrootd-for-3.6; 3.5; osg, osg-upcoming > 3.6/osg
+  #- opensciencegrid:xrootd-for-3.6; 3.5; osg > 3.6/osg-minefield
+  #- opensciencegrid:xrootd-for-3.6; 3.5; osg, osg-upcoming > 3.6/osg-minefield
+  #- opensciencegrid:xrootd-for-3.6; 3.6; osg > osg-minefield
+  #- opensciencegrid:xrootd-for-3.6; 3.6; osg-minefield
 
 package_sets:
   #### Required ####


### PR DESCRIPTION
- Add prerelease tests for xrootd for OSG 3.6
- Run osg36-xrootd tests from production since we have released it in production
