### PR TITLE
Throttle CreateImage and other local IO jobs

### DIFF
--- a/bin/generate-dag
+++ b/bin/generate-dag
@@ -20,7 +20,7 @@ DAG_FRAGMENT = '''
 JOB CreateImage{serial} create-io-image.sub
 VARS CreateImage{serial} serial="{serial}"
 RETRY CreateImage{serial} 3
-CATEGORY CreateImage{serial} CreateImage
+CATEGORY CreateImage{serial} LocalIO
 
 JOB TestRun{serial} single-test-run.sub
 VARS TestRun{serial} serial="{serial}" platform="{platform}" jobpriority="{priority}"
@@ -29,6 +29,7 @@ SCRIPT POST TestRun{serial} ../bin/write-job-id {serial} $JOBID
 
 JOB ProcessResult{serial} process-job-output.sub
 VARS ProcessResult{serial} serial="{serial}"
+CATEGORY ProcessResult{serial} LocalIO
 
 JOB CleanOutput{serial} clean-job-output.sub
 VARS CleanOutput{serial} serial="{serial}"
@@ -137,9 +138,9 @@ if __name__ == '__main__':
                 process += 1
 
     dag_contents += '\n'
-    dag_contents += '# Don\'t run too many simultaneous CreateImage jobs because they are I/O-heavy\n'
+    dag_contents += '# Don\'t run too many simultaneous LocalIO jobs because they are I/O-heavy\n'
     dag_contents += '# and run on the local machine\n';
-    dag_contents += 'MAXJOBS CreateImage 10\n'
+    dag_contents += 'MAXJOBS LocalIO 10\n'
     dag_contents += '# Allow DAG to complete successfully if any tests have failed\n'
     dag_contents += 'FINAL MarkDagSuccessful true.sub\n'
     vmu.write_file(dag_contents, os.path.join(test_run_directory, 'test-run.dag'))

--- a/bin/generate-dag
+++ b/bin/generate-dag
@@ -140,7 +140,7 @@ if __name__ == '__main__':
     dag_contents += '\n'
     dag_contents += '# Don\'t run too many simultaneous LocalIO jobs because they are I/O-heavy\n'
     dag_contents += '# and run on the local machine\n';
-    dag_contents += 'MAXJOBS LocalIO 10\n'
+    dag_contents += 'MAXJOBS LocalIO 20\n'
     dag_contents += '# Allow DAG to complete successfully if any tests have failed\n'
     dag_contents += 'FINAL MarkDagSuccessful true.sub\n'
     vmu.write_file(dag_contents, os.path.join(test_run_directory, 'test-run.dag'))

--- a/bin/generate-dag
+++ b/bin/generate-dag
@@ -20,6 +20,7 @@ DAG_FRAGMENT = '''
 JOB CreateImage{serial} create-io-image.sub
 VARS CreateImage{serial} serial="{serial}"
 RETRY CreateImage{serial} 3
+CATEGORY CreateImage CreateImage{serial}
 
 JOB TestRun{serial} single-test-run.sub
 VARS TestRun{serial} serial="{serial}" platform="{platform}" jobpriority="{priority}"
@@ -136,6 +137,9 @@ if __name__ == '__main__':
                 process += 1
 
     dag_contents += '\n'
+    dag_contents += '# Don\'t run too many simultaneous CreateImage jobs because they are I/O-heavy\n'
+    dag_contents += '# and run on the local machine\n';
+    dag_contents += 'MAXJOBS CreateImage 10\n'
     dag_contents += '# Allow DAG to complete successfully if any tests have failed\n'
     dag_contents += 'FINAL MarkDagSuccessful true.sub\n'
     vmu.write_file(dag_contents, os.path.join(test_run_directory, 'test-run.dag'))

--- a/bin/generate-dag
+++ b/bin/generate-dag
@@ -20,7 +20,7 @@ DAG_FRAGMENT = '''
 JOB CreateImage{serial} create-io-image.sub
 VARS CreateImage{serial} serial="{serial}"
 RETRY CreateImage{serial} 3
-CATEGORY CreateImage CreateImage{serial}
+CATEGORY CreateImage{serial} CreateImage
 
 JOB TestRun{serial} single-test-run.sub
 VARS TestRun{serial} serial="{serial}" platform="{platform}" jobpriority="{priority}"


### PR DESCRIPTION
- Don't run too many simultaneous CreateImage jobs because they are I/O-heavy and run on the local machine so it just slows things down
- Fix ordering for CATEGORY statement
- Also throttle ProcessResult nodes (extract-job-output reads from disk images)
- 20 ends up better
