### PR TITLE
decode stdout/stderr from run_command (SOFTWARE-5451)

### DIFF
--- a/bin/create-io-image
+++ b/bin/create-io-image
@@ -20,7 +20,8 @@ def run_command(command, shell=False):
         raise TypeError('Need list or tuple, got %s' % (repr(command)))
 
     # Run and return command
-    p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=shell)
+    p = subprocess.Popen(command, encoding='utf-8', stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE, shell=shell)
     (stdout, stderr) = p.communicate()
     return (p.returncode, stdout, stderr)
 


### PR DESCRIPTION
by default Popen.communicate() returns bytes objects, which are printed in a few places - and show up in the logs as b'...', which is especially annoying due to all the escaped internal newlines.

@matyasselmeci - would you prefer `encoding="latin1"` or anything?  I think that would make the prints print garbage if there is actual utf8 data in stdout/stderr, though I know sometimes you like to guard against stray bits.