### PR TITLE
bump request_disk for el9 jobs (SOFTWARE-5451)

### DIFF
--- a/jobs/single-test-run.sub
+++ b/jobs/single-test-run.sub
@@ -14,7 +14,7 @@ periodic_release        = ( (HoldReasonCode == 3) && (NumJobStarts < 3) ) || ( (
 # We can remove jobs since the DAG can handle removed nodes
 periodic_remove         = ( (JobStatus == 5) && (HoldReasonCode =?= 3) && (NumJobStarts >= 3) ) || (time() - QDate >  43200)
 
-request_disk            = 8GB
+request_disk            = 16GB
 # NOTE: Please inform infrastructure of machines in the following list:
 +BadMachineList         = ""
 requirements            = (TARGET.HasVirshDefaultNetwork == True) && (TARGET.HasCHTCStaging == True) && !StringListMember(TARGET.Machine, MY.BadMachineList)


### PR DESCRIPTION
we create 10000M images for el9; we need a tad more for the input disk, and we'll give some cushion room for the images to expand later.