### PR TITLE
enable *upcoming*-minefield for upcoming el9 tests (SOFTWARE-5337)

### DIFF
--- a/parameters.d/osg36-upcoming-el9.yaml
+++ b/parameters.d/osg36-upcoming-el9.yaml
@@ -24,8 +24,9 @@ sources:
   # - opensciencegrid:master; 3.6; osg > osg-testing
   - opensciencegrid:master; 3.6; osg, osg-upcoming
   - opensciencegrid:master; 3.6; osg-testing, osg-upcoming-testing
+  - opensciencegrid:master; 3.6; osg-minefield, osg-upcoming-minefield
   # - opensciencegrid:master; 3.6; osg > osg-testing, osg-upcoming-testing
-  - opensciencegrid:master; 3.6; osg-minefield
+  # - opensciencegrid:master; 3.6; osg-minefield
   # - opensciencegrid:master; 3.6; osg > osg-minefield
 
 package_sets:


### PR DESCRIPTION
Noticed this from last night's nightlies - we do an osg-minefield install for the upcoming tests but not osg-upcoming-minefield (it should be the latter, of course)

https://osg-sw-submit.chtc.wisc.edu/tests/20230203-0423/packages.html