### PR TITLE
Have separate CE tests for each batch system

### DIFF
--- a/parameters.d/osg36-el8.yaml
+++ b/parameters.d/osg36-el8.yaml
@@ -39,9 +39,13 @@ package_sets:
   # osg_java - Pre-install OSG java packages (default: False)
   # rng - Install entropy generation package (default: False)
   ##################
-  - label: Compute Entrypoint (no Torque)
+  - label: Compute Entrypoint (Condor)
     packages:
       - osg-ce-condor
+      - htcondor-ce-view
+  - label: Compute Entrypoint (SLURM)
+    packages:
+      - osg-ce-slurm
       - htcondor-ce-view
       - slurm
       - slurm-slurmd

--- a/parameters.d/osg36-el9.yaml
+++ b/parameters.d/osg36-el9.yaml
@@ -37,9 +37,13 @@ package_sets:
   # osg_java - Pre-install OSG java packages (default: False)
   # rng - Install entropy generation package (default: False)
   ##################
-  - label: Compute Entrypoint (no Torque)
+  - label: Compute Entrypoint (Condor)
     packages:
       - osg-ce-condor
+      - htcondor-ce-view
+  - label: Compute Entrypoint (SLURM)
+    packages:
+      - osg-ce-slurm
       - htcondor-ce-view
       - slurm
       - slurm-slurmd

--- a/parameters.d/osg36.yaml
+++ b/parameters.d/osg36.yaml
@@ -39,19 +39,28 @@ package_sets:
   # osg_java - Pre-install OSG java packages (default: False)
   # rng - Install entropy generation package (default: False)
   ##################
-  - label: Compute Entrypoint
+  - label: Compute Entrypoint (Condor)
     packages:
       - osg-ce-condor
       - htcondor-ce-view
-      - torque-server
-      - torque-mom
-      - torque-client
-      - torque-scheduler
+  - label: Compute Entrypoint (SLURM)
+    packages:
+      - osg-ce-slurm
+      - htcondor-ce-view
       - slurm
       - slurm-slurmd
       - slurm-slurmctld
       - slurm-perlapi
       - slurm-slurmdbd
+      - mariadb-server
+  - label: Compute Entrypoint (Torque)
+    packages:
+      - osg-ce-pbs
+      - htcondor-ce-view
+      - torque-server
+      - torque-mom
+      - torque-client
+      - torque-scheduler
       - mariadb-server
   - label: Central Collector
     packages:


### PR DESCRIPTION
- This lets us install the CE package specific to that batch system instead of using "osg-ce-condor" along with SLURM and Torque.
- Also it's closer to what's actually installed on systems since most sites don't have both SLURM and PBS and Condor on the same submit host.