### PR TITLE
Increase output disk allotment to contain possible larger outputs

### DIFF
--- a/bin/create-io-image
+++ b/bin/create-io-image
@@ -125,7 +125,7 @@ def create_image(config_filename):
         os.environ["LIBGUESTFS_DEBUG"] = "1"
         os.environ["LIBGUESTFS_TRACE"] = "1"
         print(f'Making "{image_filename}" from "{image_directory}"')
-        return_code, stdout, stderr = run_command(['virt-make-fs', '--size=10M', '--format=qcow2',
+        return_code, stdout, stderr = run_command(['virt-make-fs', '--size=64M', '--format=qcow2',
                                                    image_directory, image_filename])
 
         shutil.rmtree(image_directory)


### PR DESCRIPTION
When the HTCondor-CE failed to submit a job to the HTCondor batch system, the output grew to 30 MB. The log tar file was truncated. So, I chose 64MB capacity. Note: the disk space is not preallocated.