### PR TITLE
Add initial OSG 23 support (SOFTWARE-5628)

### DIFF
--- a/bin/run-job
+++ b/bin/run-job
@@ -46,21 +46,23 @@ osg_series=`grep series $INPUT_DIR/osg-test.conf | sed -e 's/series *= *//'`
 # Set variables based on OS major version
 os_major_version=`sed -e 's/^[^0-9]*//' -e 's/\..*$//' /etc/redhat-release`
 epel_url="https://dl.fedoraproject.org/pub/epel/epel-release-latest-$os_major_version.noarch.rpm"
+
+# Starting with OSG 23, we dump release RPMs in the XX-main part of the tree
+[[ $osg_series =~ ^[2-9][0-9]$ ]] && osg_series=${osg_series}-main
+osg_url="https://repo.opensciencegrid.org/osg/${osg_series}/osg-${osg_series}-el${os_major_version}-release-latest.rpm"
+
 case $os_major_version in
     7 )
-        osg_url="https://repo.opensciencegrid.org/osg/$osg_series/osg-$osg_series-el7-release-latest.rpm"
         priorities_rpm='yum-plugin-priorities'
         python_lib_dir='/usr/lib/python3.6'
         python='/usr/bin/python3'
         ;;
     8 )
-        osg_url="https://repo.opensciencegrid.org/osg/$osg_series/osg-$osg_series-el8-release-latest.rpm"
         priorities_rpm=
         python_lib_dir='/usr/lib/python3.6'
         python='/usr/bin/python3'
         ;;
     9 )
-        osg_url="https://repo.opensciencegrid.org/osg/$osg_series/osg-$osg_series-el9-release-latest.rpm"
         priorities_rpm=
         python_lib_dir='/usr/lib/python3.9'
         python='/usr/bin/python3'

--- a/parameters.d/osg23.yaml
+++ b/parameters.d/osg23.yaml
@@ -21,8 +21,8 @@ sources:
   # 3.3-testing and 3-3-upcoming-testing:
   # 3.2; osg, osg-testing > 3.3/osg-testing, osg-upcoming-testing
   ###################
-  - opensciencegrid:master; 3.6; osg, osg-upcoming > 23/osg-development
-  - opensciencegrid:master; 23; osg-development
+  - opensciencegrid:master; 3.6; osg, osg-upcoming > 23/osg-minefield
+  - opensciencegrid:master; 23; osg-minefield
 
 package_sets:
   #### Required ####

--- a/parameters.d/osg23.yaml
+++ b/parameters.d/osg23.yaml
@@ -1,0 +1,93 @@
+###################
+# OSG 23 tests
+# File format documention:
+# https://github.com/opensciencegrid/vm-test-runs#running-osg-test-in-vm-universe
+###################
+
+platforms:
+  - centos_stream_8_x86_64
+  - rocky_8_x86_64
+  - alma_8_x86_64
+  - centos_stream_9_x86_64
+  - rocky_9_x86_64
+  - alma_9_x86_64
+
+sources:
+  ###################
+  # Format:
+  # [<Github account>:<osg-test branch>;] <OSG ver>; <REPO 1, REPO 2...REPO N> [> <Update OSG ver>/<Update REPO 1, REPO 2...REPO N>]
+  # Example:
+  # Run osg-test (from 3.2-minefield) with packages from 3.2-release and 3.2-testing that are then upgraded to
+  # 3.3-testing and 3-3-upcoming-testing:
+  # 3.2; osg, osg-testing > 3.3/osg-testing, osg-upcoming-testing
+  ###################
+  - opensciencegrid:master; 3.6; osg, osg-upcoming > 23/osg-development
+  - opensciencegrid:master; 23; osg-development
+
+package_sets:
+  #### Required ####
+  # label - used for reporting, should be consistent across param files
+  # packages - list of packages to install in the test run
+  #### Optional ####
+  # selinux - enable SELinux for the package set, otherwise Permissive mode (default: True)
+  # osg_java - Pre-install OSG java packages (default: False)
+  # rng - Install entropy generation package (default: False)
+  ##################
+  - label: Compute Entrypoint (Condor)
+    packages:
+      - osg-ce-condor
+      - htcondor-ce-view
+  - label: Compute Entrypoint (Slurm)
+    packages:
+      - osg-ce-slurm
+      - htcondor-ce-view
+      - slurm
+      - slurm-slurmd
+      - slurm-slurmctld
+      - slurm-perlapi
+      - slurm-slurmdbd
+      - mariadb-server
+  - label: Compute Entrypoint (Torque)
+    packages:
+      - osg-ce-pbs
+      - htcondor-ce-view
+      - torque-server
+      - torque-mom
+      - torque-client
+      - torque-scheduler
+      - mariadb-server
+  - label: Central Collector
+    packages:
+      - htcondor-ce-collector
+      - htcondor-ce-view
+      - fetch-crl
+  - label: StashCache
+    packages:
+      - /usr/bin/stashcp
+      - stash-cache
+      - stash-origin
+      - python3-gfal2-util
+      - gfal2-all
+  - label: Worker Node (privileged)
+    packages:
+      - osg-wn-client
+      - osg-oasis
+      - apptainer-suid
+  - label: Worker Node (privileged, tarball deps)
+    packages:
+      - hosted-ce-tools
+      - osg-update-data
+      - osg-wn-client
+  - label: XRootD
+    packages:
+      - osg-xrootd-standalone
+      - xrootd-multiuser
+      - xrootd-client
+      - voms-clients-cpp
+  - label: GlideinwmsFrontend
+    packages:
+      - glideinwms-vofrontend
+  - label: GlideinwmsFactory
+    packages:
+      - glideinwms-factory
+


### PR DESCRIPTION
We have to use `development` instead of `minefield` since HTCSS packages aren't available in `minefield` (I think we need to add the HTCSS daily repos as an external repo?).