### PR TITLE
Boost Priority of Creating Images

### DIFF
--- a/bin/generate-dag
+++ b/bin/generate-dag
@@ -19,6 +19,7 @@ DAG_FRAGMENT = '''
 #########################
 JOB CreateImage{serial} create-io-image.sub
 VARS CreateImage{serial} serial="{serial}"
+PRIORITY 2
 RETRY CreateImage{serial} 3
 CATEGORY CreateImage{serial} LocalIO
 


### PR DESCRIPTION
Otherwise, the process-results and clean-output jobs starve out creating images, which limits the number of simultaneous test-runs.