### PR TITLE
Fix issue with mismatched package sets (SOFTWARE-6021)

### DIFF
--- a/parameters.d-prerelease/osg23-only.yaml
+++ b/parameters.d-prerelease/osg23-only.yaml
@@ -1,0 +1,20 @@
+---
+platforms:
+  - rocky_8_x86_64
+  - alma_8_x86_64
+  - centos_stream_9_x86_64
+  - rocky_9_x86_64
+  - alma_9_x86_64
+
+sources:
+  - opensciencegrid:master; 23; osg-prerelease
+  - opensciencegrid:master; 23; osg > osg-prerelease
+  - opensciencegrid:master; 23; osg-prerelease, osg-upcoming-prerelease, osg-upcoming
+  - opensciencegrid:master; 23; osg > osg-prerelease, osg-upcoming-prerelease, osg-upcoming
+
+package_sets:
+  - label: Worker Node (privileged, tarball deps + hosted-ce-tools)
+    packages:
+      - hosted-ce-tools
+      - osg-update-data
+      - osg-wn-client

--- a/parameters.d-prerelease/osg24-only.yaml
+++ b/parameters.d-prerelease/osg24-only.yaml
@@ -1,0 +1,19 @@
+---
+platforms:
+  - rocky_8_x86_64
+  - alma_8_x86_64
+  - centos_stream_9_x86_64
+  - rocky_9_x86_64
+  - alma_9_x86_64
+
+sources:
+  - opensciencegrid:master; 24; osg-prerelease
+  - opensciencegrid:master; 24; osg > osg-prerelease
+  - opensciencegrid:master; 24; osg-prerelease, osg-upcoming-prerelease, osg-upcoming
+  - opensciencegrid:master; 24; osg > osg-prerelease, osg-upcoming-prerelease, osg-upcoming
+
+package_sets:
+  - label: Worker Node (privileged, tarball deps)
+    packages:
+      - osg-update-data
+      - osg-wn-client

--- a/parameters.d/osg23-el8.yaml
+++ b/parameters.d/osg23-el8.yaml
@@ -70,7 +70,7 @@ package_sets:
       - osg-wn-client
       - osg-oasis
       - apptainer-suid
-  - label: Worker Node (privileged, tarball deps)
+  - label: Worker Node (privileged, tarball deps + hosted-ce-tools)
     packages:
       - hosted-ce-tools
       - osg-update-data

--- a/parameters.d/osg23-el9.yaml
+++ b/parameters.d/osg23-el9.yaml
@@ -81,7 +81,7 @@ package_sets:
       - osg-wn-client
       - osg-oasis
       - apptainer-suid
-  - label: Worker Node (privileged, tarball deps)
+  - label: Worker Node (privileged, tarball deps + hosted-ce-tools)
     packages:
       - hosted-ce-tools
       - osg-update-data


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/osgtest/runs/run-20241027-0423/bin/generate-dag", line 109, in <module>
    vmu.flatten_run_params(run_params) # verify uniqueness of package sets + labels
  File "/home/runs/run-20241027-0423/bin/vmu.py", line 64, in flatten_run_params
    if item in result[section]:
  File "/home/runs/run-20241027-0423/bin/vmu.py", line 182, in __eq__
    raise ParamError("Package set label '%s' refers to different sets of packages" % self.label)
vmu.ParamError: Package set label 'Worker Node (privileged, tarball deps)' refers to different sets of packages
```