### PR TITLE
Add htcss2002.chtc.wisc.edu to the naughty list

### DIFF
--- a/jobs/single-test-run.sub
+++ b/jobs/single-test-run.sub
@@ -44,6 +44,7 @@ request_disk            = 16GB
  e2483.chtc.wisc.edu,\
  e2485.chtc.wisc.edu,\
  e4028.chtc.wisc.edu,\
+ htcss2002.chtc.wisc.edu,\
  txie-dsigpu4000.chtc.wisc.edu,\
  voyles2000.chtc.wisc.edu,\
 "


### PR DESCRIPTION
(the usual "no apparent IP address" error)