### PR TITLE
Drop test run retention by 20%

### DIFF
--- a/bin/vm-test-cleanup
+++ b/bin/vm-test-cleanup
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RUNS_TO_KEEP=100
+RUNS_TO_KEEP=80
 
 year='20[1-9][0-9]'
 month='[01][0-9]'


### PR DESCRIPTION
We're running into space issues in /var and this is the easiest way to
resolve it