### PR TITLE
Delete commented-out XCache test set for OSG 24 yamls

### DIFF
--- a/parameters.d/osg24-el8.yaml
+++ b/parameters.d/osg24-el8.yaml
@@ -58,14 +58,6 @@ package_sets:
       - htcondor-ce-collector
       - htcondor-ce-view
       - fetch-crl
-#  TODO: Migrate these tests from osdf to pelican
-#  - label: XCache
-#    packages:
-#      - /usr/bin/stashcp
-#      - stash-cache
-#      - stash-origin
-#      - python3-gfal2-util
-#      - gfal2-all
   - label: Worker Node (privileged)
     packages:
       - osg-wn-client

--- a/parameters.d/osg24-el9-aarch64.yaml
+++ b/parameters.d/osg24-el9-aarch64.yaml
@@ -66,14 +66,6 @@ package_sets:
       - htcondor-ce-collector
       - htcondor-ce-view
       - fetch-crl
-#  TODO: Migrate these tests from osdf to pelican
-#  - label: XCache
-#    packages:
-#      - /usr/bin/stashcp
-#      - stash-cache
-#      - stash-origin
-#      - python3-gfal2-util
-#      - gfal2-all
   - label: Worker Node (privileged)
     packages:
       - osg-wn-client

--- a/parameters.d/osg24-el9.yaml
+++ b/parameters.d/osg24-el9.yaml
@@ -69,14 +69,6 @@ package_sets:
       - htcondor-ce-collector
       - htcondor-ce-view
       - fetch-crl
-#  TODO: Migrate these tests from osdf to pelican
-#  - label: XCache
-#    packages:
-#      - /usr/bin/stashcp
-#      - stash-cache
-#      - stash-origin
-#      - python3-gfal2-util
-#      - gfal2-all
   - label: Worker Node (privileged)
     packages:
       - osg-wn-client


### PR DESCRIPTION
OSG 24 does not have stash-cache or stash-origin. Pelican tests, once written, should be a separate test set.