### PR TITLE
Update test result header parsing regex to account for difference in el9/10 result name

### DIFF
--- a/bin/analyze_job_output.py
+++ b/bin/analyze_job_output.py
@@ -109,7 +109,7 @@ def parse_log(osg_test_log, test_exceptions, components):
     problems = []
     ignored_failures = 0
     cleanup_failures = 0
-    for m in re.finditer(r'^(ERROR|FAIL): (\w+) \(osgtest\.tests\.(\w+)\.(\w+)\)', osg_test_log, re.MULTILINE):
+    for m in re.finditer(r'^(ERROR|FAIL): (\w+) \(osgtest\.tests\.(\w+)\.(\w+).*\)', osg_test_log, re.MULTILINE):
         status, function, module, module_name = m.groups()
         if module == 'special_cleanup':
             cleanup_failures += 1


### PR DESCRIPTION
```
EL9: # test name is both leading and trailing
======================================================================
FAIL: test_02_install_packages (osgtest.tests.special_install.TestInstall.test_02_install_packages)
----------------------------------------------------------------------


EL10: # missing the trailing test name
======================================================================
FAIL: test_02_install_packages (osgtest.tests.special_install.TestInstall)
----------------------------------------------------------------------
```